### PR TITLE
feat: update visual style, layout in landscape & improved ticket/change logic

### DIFF
--- a/game.html
+++ b/game.html
@@ -30,7 +30,7 @@
             <div class="big" id="need">—</div>
           </div>
           <div class="card">
-            <div class="meta">To pay</div>
+            <div class="meta">Pays</div>
             <div class="big" id="pays">$0.00</div>
           </div>
           <div class="card">

--- a/js/game/actions.js
+++ b/js/game/actions.js
@@ -62,12 +62,16 @@ export function insertCoin(session, value) {
   session.coinsUsed[roundedValue] = (session.coinsUsed[roundedValue] || 0) + 1;
   session.inserted = round(session.inserted + roundedValue);
   const formatted = currency.format(roundedValue);
-  logHistory(session, 'Inserted', `+${formatted}`);
+  if (!session.showChange) {
+    session.showChange = true;
+  }
+  logHistory(session, 'Returned', `+${formatted}`);
   return true;
 }
 
 export function resetCoins(session) {
   session.coinsUsed = {};
   session.inserted = 0;
-  logHistory(session, 'Coins returned', '$0.00');
+  session.showChange = false;
+  logHistory(session, 'Change cleared', '$0.00');
 }

--- a/js/game/constants.js
+++ b/js/game/constants.js
@@ -1,15 +1,39 @@
 export const ALL_TICKETS = [
-  { name: 'Normal', price: 1.2, className: 't-normal' },
-  { name: 'Kid', price: 0.5, className: 't-kid' },
-  { name: 'Luggage', price: 0.6, className: 't-luggage' },
-  { name: 'Senior', price: 0.8, className: 't-senior' },
-  { name: 'Disabled', price: 0.6, className: 't-disabled' },
-  { name: 'Baby Stroller', price: 0.7, className: 't-stroller' },
-  { name: 'Bike', price: 0.9, className: 't-bike' },
-  { name: 'Tourist', price: 1.5, className: 't-tourist' },
+  { name: 'Normal', price: 1.2, className: 't-normal', icon: '🧍' },
+  { name: 'Kid', price: 0.5, className: 't-kid', icon: '🧒' },
+  { name: 'Luggage', price: 0.6, className: 't-luggage', icon: '🧳' },
+  { name: 'Senior', price: 0.8, className: 't-senior', icon: '👴' },
+  { name: 'Disabled', price: 0.6, className: 't-disabled', icon: '♿' },
+  { name: 'Baby Stroller', price: 0.7, className: 't-stroller', icon: '👶' },
+  { name: 'Bike', price: 0.9, className: 't-bike', icon: '🚲' },
+  { name: 'Tourist', price: 1.5, className: 't-tourist', icon: '🧭' },
 ];
 
-export const COINS = [5, 2, 1, 0.5, 0.25, 0.1, 0.05, 0.01];
+export const DENOMINATIONS = [
+  { value: 5, type: 'bill', size: 'lg', skin: 'emerald', label: 'Transit bill', icon: '💵', toggleKey: 'allowFive' },
+  { value: 2, type: 'bill', size: 'lg', skin: 'teal', label: 'Express bill', icon: '💴', toggleKey: 'allowTwo' },
+  { value: 1, type: 'coin', size: 'lg', skin: 'brass', label: 'Dollar coin', icon: '●' },
+  { value: 0.5, type: 'coin', size: 'lg', skin: 'silver', label: 'Half coin', icon: '◎' },
+  { value: 0.1, type: 'coin', size: 'sm', skin: 'silver', label: 'Dime', icon: '◉' },
+  { value: 0.05, type: 'coin', size: 'sm', skin: 'copper', label: 'Nickel', icon: '◍' },
+  { value: 0.01, type: 'coin', size: 'xs', skin: 'copper', label: 'Penny', icon: '∙', toggleKey: 'allowOneCent' },
+];
+
+export const COIN_TOGGLES = {
+  allowFive: true,
+  allowTwo: true,
+  allowOneCent: true,
+};
+
+export function getAvailableDenominations(overrides = {}) {
+  const toggles = { ...COIN_TOGGLES, ...overrides };
+  return DENOMINATIONS.filter((item) => {
+    if (!item.toggleKey) {
+      return true;
+    }
+    return toggles[item.toggleKey] !== false;
+  });
+}
 
 export const GAME_MODES = {
   TB1: { label: 'Top/Bottom 1', timeLimit: 20, description: 'Classic rush with single passenger focus.' },

--- a/js/game/render.js
+++ b/js/game/render.js
@@ -26,7 +26,7 @@ export function renderTickets(session, elements, handlers) {
   session.available.forEach((ticket) => {
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = `btn ${ticket.className}`;
+    button.className = `btn ticket ${ticket.className}`;
     const count = session.selectedTickets[ticket.name] || 0;
     const need = session.request[ticket.name] || 0;
     if (need > 0 && count >= need) {
@@ -35,8 +35,9 @@ export function renderTickets(session, elements, handlers) {
 
     button.innerHTML = `
       ${count ? `<span class="bubble">×${count}</span>` : ''}
+      <div class="ticket-icon" aria-hidden="true">${ticket.icon ?? ''}</div>
       <div class="sub">${ticket.name}</div>
-      <div>${formatMoney(ticket.price)}</div>
+      <div class="ticket-price">${formatMoney(ticket.price)}</div>
     `;
 
     button.addEventListener('click', () => handlers.onAddTicket(ticket.name));
@@ -55,15 +56,27 @@ export function renderCoins(session, elements, handlers) {
   const { coinsWrap } = elements;
   const fragment = document.createDocumentFragment();
 
-  handlers.availableCoins.forEach((value, index) => {
+  const denominations =
+    typeof handlers.getAvailableCoins === 'function' ? handlers.getAvailableCoins() : handlers.availableCoins;
+
+  denominations.forEach((denomination) => {
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = `btn ${index === 0 ? 'bill' : 'coin'}`;
+    const classes = ['btn', 'denomination', denomination.type];
+    if (denomination.size) {
+      classes.push(`size-${denomination.size}`);
+    }
+    if (denomination.skin && (denomination.type === 'bill' || denomination.skin !== 'brass')) {
+      classes.push(`skin-${denomination.skin}`);
+    }
+    button.className = classes.join(' ');
+    button.dataset.value = String(denomination.value);
     button.innerHTML = `
-      <div class="sub">${index === 0 ? 'Bill' : 'Coin'}</div>
-      <div>${formatMoney(value)}</div>
+      <span class="denom-icon" aria-hidden="true">${denomination.icon ?? ''}</span>
+      <span class="denom-value">${formatMoney(denomination.value)}</span>
+      <span class="denom-label">${denomination.label}</span>
     `;
-    button.addEventListener('click', () => handlers.onInsertCoin(value));
+    button.addEventListener('click', () => handlers.onInsertCoin(denomination.value));
     fragment.appendChild(button);
   });
 
@@ -71,19 +84,49 @@ export function renderCoins(session, elements, handlers) {
 }
 
 export function updateHud(session, elements) {
-  const { scoreDisplay, needEl, paysEl, fareEl, pickedEl, remainEl, timerDisplay } = elements;
+  const { scoreDisplay, needEl, paysEl, fareEl, pickedEl, remainEl, timerDisplay, changeWrap } = elements;
   scoreDisplay.textContent = Math.max(0, Math.round(session.score));
   needEl.textContent = formatRequest(session.request);
   paysEl.textContent = formatMoney(session.pays);
   fareEl.textContent = formatMoney(session.ticketTotal);
   pickedEl.textContent = formatMoney(session.selectedTotal);
-  const delta = session.inserted - session.pays;
-  const label = delta >= 0 ? 'Change' : 'To pay';
-  if (remainEl.dataset.role !== label) {
-    remainEl.dataset.role = label;
-    remainEl.previousElementSibling.textContent = label;
+  const revealChange = session.showChange || session.changeDue === 0;
+  if (changeWrap) {
+    changeWrap.dataset.visible = revealChange ? 'true' : 'false';
   }
-  remainEl.textContent = formatMoney(Math.abs(delta));
+
+  const labelNode = remainEl.previousElementSibling;
+  if (!revealChange) {
+    remainEl.textContent = '— —';
+    remainEl.removeAttribute('data-state');
+    if (labelNode) {
+      labelNode.textContent = 'Change';
+    }
+  } else {
+    const remaining = Math.round((session.changeDue - session.inserted) * 100) / 100;
+    let stateLabel = '';
+    let state = '';
+    if (Math.abs(remaining) < 0.005) {
+      stateLabel = session.changeDue > 0 ? 'Change exact' : 'No change due';
+      remainEl.textContent = formatMoney(0);
+    } else if (remaining > 0) {
+      stateLabel = 'Change due';
+      remainEl.textContent = formatMoney(remaining);
+      state = 'short';
+    } else {
+      stateLabel = 'Extra given';
+      remainEl.textContent = formatMoney(Math.abs(remaining));
+      state = 'over';
+    }
+    if (labelNode && labelNode.textContent !== stateLabel) {
+      labelNode.textContent = stateLabel;
+    }
+    if (state) {
+      remainEl.dataset.state = state;
+    } else {
+      remainEl.removeAttribute('data-state');
+    }
+  }
   timerDisplay.textContent = `${Math.max(0, Math.ceil(session.timeLeft))} s`;
 }
 

--- a/js/game/round.js
+++ b/js/game/round.js
@@ -57,9 +57,11 @@ export function startRound(elements, handlers) {
   SESSION.available = rollBusConfig();
   SESSION.request = rollRequest(SESSION.available);
   SESSION.ticketTotal = Number(fareOf(SESSION.request).toFixed(2));
-  SESSION.pays = rollPayment(SESSION.ticketTotal);
+  const payment = rollPayment(SESSION.ticketTotal);
+  SESSION.pays = payment.pays;
+  SESSION.changeDue = Number(payment.change.toFixed(2));
   SESSION.history = [];
-  SESSION.showChange = false;
+  SESSION.showChange = SESSION.changeDue === 0;
 
   hideOverlay(handlers.overlayElements.overlay);
 
@@ -78,7 +80,11 @@ export function finishRound(elements, handlers, reason) {
 
   const perfectTickets = requestsMatch(SESSION.request, SESSION.selectedTickets);
   const ticketValueMatch = Math.abs(SESSION.selectedTotal - SESSION.ticketTotal) < 0.01;
-  const paymentDelta = roundValue(SESSION.inserted - SESSION.pays);
+  const changeDelta = roundValue(SESSION.inserted - SESSION.changeDue);
+  const totalCoinsUsed = Object.values(SESSION.coinsUsed).reduce((sum, count) => sum + count, 0);
+  const uniqueCoinsUsed = Object.keys(SESSION.coinsUsed).filter((key) => SESSION.coinsUsed[key] > 0).length;
+  const hasPerfectChange =
+    Math.abs(changeDelta) < 0.01 && totalCoinsUsed >= 3 && uniqueCoinsUsed >= 2 && SESSION.changeDue > 0;
 
   let points = 0;
   if (perfectTickets) {
@@ -89,10 +95,12 @@ export function finishRound(elements, handlers, reason) {
     points -= 20;
   }
 
-  if (Math.abs(paymentDelta) < 0.01) {
+  if (hasPerfectChange) {
     points += 30;
-  } else if (paymentDelta > 0) {
-    points += 10;
+  } else if (Math.abs(changeDelta) < 0.01) {
+    points += 12;
+  } else if (changeDelta > 0) {
+    points += 6;
   } else {
     points -= 30;
   }
@@ -105,9 +113,10 @@ export function finishRound(elements, handlers, reason) {
     points,
     perfectTickets,
     ticketValueMatch,
-    paymentDelta,
+    changeDelta,
     timeLeft: SESSION.timeLeft,
     reason,
+    coinsUsed: totalCoinsUsed,
   });
 
   const details = [
@@ -116,17 +125,23 @@ export function finishRound(elements, handlers, reason) {
       value: perfectTickets ? 'Perfect match' : ticketValueMatch ? 'Value matched' : 'Mismatch',
     },
     {
-      label: 'Payment',
+      label: 'Change',
       value:
-        paymentDelta === 0
-          ? 'Exact'
-          : paymentDelta > 0
-          ? `${formatMoney(paymentDelta)} change`
-          : `${formatMoney(paymentDelta)} missing`,
+        Math.abs(changeDelta) < 0.01
+          ? hasPerfectChange
+            ? 'Perfect combo'
+            : 'Exact'
+          : changeDelta > 0
+          ? `${formatMoney(changeDelta)} extra`
+          : `${formatMoney(Math.abs(changeDelta))} missing`,
     },
     {
       label: 'Time left',
       value: `${Math.round(SESSION.timeLeft)} s`,
+    },
+    {
+      label: 'Coins used',
+      value: `${totalCoinsUsed} (${uniqueCoinsUsed} types)`,
     },
   ];
 

--- a/js/game/state.js
+++ b/js/game/state.js
@@ -1,4 +1,8 @@
-import { GAME_MODES, DEFAULT_MODE, TOTAL_ROUNDS } from './constants.js';
+import { GAME_MODES, DEFAULT_MODE, TOTAL_ROUNDS, COIN_TOGGLES } from './constants.js';
+
+function defaultCoinOptions() {
+  return { ...COIN_TOGGLES };
+}
 
 function resolveMode(mode) {
   if (mode && GAME_MODES[mode]) {
@@ -13,6 +17,7 @@ function baseRoundState(timeLimit) {
     request: {},
     ticketTotal: 0,
     pays: 0,
+    changeDue: 0,
     selectedTickets: {},
     selectedTotal: 0,
     coinsUsed: {},
@@ -30,6 +35,7 @@ export const SESSION = {
   totalRounds: TOTAL_ROUNDS,
   score: 0,
   roundSummaries: [],
+  coinOptions: defaultCoinOptions(),
   ...baseRoundState(GAME_MODES[DEFAULT_MODE].timeLimit),
 };
 
@@ -44,6 +50,7 @@ export function startSession(player, mode) {
   SESSION.score = 0;
   SESSION.roundSummaries = [];
   SESSION.totalRounds = TOTAL_ROUNDS;
+  SESSION.coinOptions = defaultCoinOptions();
 
   Object.assign(SESSION, baseRoundState(timeLimit));
 
@@ -52,7 +59,8 @@ export function startSession(player, mode) {
 
 export function resetRoundState() {
   const timeLimit = GAME_MODES[SESSION.mode].timeLimit;
-  Object.assign(SESSION, baseRoundState(timeLimit));
+  const nextState = baseRoundState(timeLimit);
+  Object.assign(SESSION, nextState, { coinOptions: SESSION.coinOptions });
 }
 
 export function endSession() {

--- a/js/screens/game.js
+++ b/js/screens/game.js
@@ -1,4 +1,4 @@
-import { COINS, GAME_MODES } from '../game/constants.js';
+import { GAME_MODES, getAvailableDenominations } from '../game/constants.js';
 import { SESSION, startSession, endSession } from '../game/state.js';
 import { startRound, finishRound, stopRound } from '../game/round.js';
 import { addTicket, removeTicket, clearTickets, insertCoin } from '../game/actions.js';
@@ -22,6 +22,7 @@ const elements = {
   ticketsWrap: document.getElementById('tickets'),
   coinsWrap: document.getElementById('coins'),
   historyList: document.getElementById('history'),
+  changeWrap: document.querySelector('.pay'),
 };
 
 const overlayElements = {
@@ -50,7 +51,7 @@ const ticketHandlers = {
 };
 
 const coinHandlers = {
-  availableCoins: COINS,
+  getAvailableCoins: () => getAvailableDenominations(SESSION.coinOptions),
   onInsertCoin: (value) => {
     if (!roundActive) return;
     insertCoin(SESSION, value);
@@ -79,8 +80,9 @@ function maybeFinishRound() {
   }
   const ticketsMatch = requestEntries.every(([name, count]) => (SESSION.selectedTickets[name] || 0) === count);
   const noExtraTickets = Object.keys(SESSION.selectedTickets).every((name) => (SESSION.request[name] || 0) === SESSION.selectedTickets[name]);
-  const paymentEnough = SESSION.inserted >= SESSION.pays && SESSION.pays > 0;
-  if (ticketsMatch && noExtraTickets && paymentEnough) {
+  const remainingChange = SESSION.changeDue - SESSION.inserted;
+  const changeSettled = SESSION.changeDue === 0 ? SESSION.inserted === 0 : remainingChange <= 0.01;
+  if (ticketsMatch && noExtraTickets && changeSettled) {
     finishing = true;
     finishRound(elements, roundHandlers, 'completed');
     roundActive = false;

--- a/styles/app.css
+++ b/styles/app.css
@@ -1,30 +1,46 @@
 :root {
   color-scheme: dark;
-  --bg: #0b1018;
-  --panel: #0e1522;
-  --panel2: #0a111c;
-  --border: #223047;
-  --text: #f3f7ff;
-  --muted: #9fb0c9;
-  --accent: #ffd54a;
-  --ok: #35d08a;
-  --bad: #ff5555;
-  --coin: #ffd54a;
-  --coinText: #1a2232;
-  --bill1: #d6f0c9;
-  --bill2: #b8e3aa;
+  --bg: #05090f;
+  --panel: #101a2a;
+  --panel2: #0b141f;
+  --panel-elevated: #142033;
+  --panel-soft: #0f1826;
+  --border: rgba(86, 115, 156, 0.42);
+  --border-strong: rgba(132, 168, 214, 0.65);
+  --text: #f4f7ff;
+  --muted: #8f9fbf;
+  --muted-strong: #cad6ec;
+  --accent: #f4b640;
+  --accent-soft: #4ba7ff;
+  --ok: #48dcb0;
+  --bad: #ff6f6f;
+  --coin-brass: #d5ab4b;
+  --coin-brass-dark: #9a7120;
+  --coin-brass-border: rgba(154, 113, 32, 0.55);
+  --coin-silver: #d7dce8;
+  --coin-silver-dark: #8890a1;
+  --coin-silver-border: rgba(164, 176, 198, 0.6);
+  --coin-copper: #f3a36b;
+  --coin-copper-dark: #a46433;
+  --coin-copper-border: rgba(208, 132, 84, 0.6);
+  --bill-emerald: #6cc5aa;
+  --bill-emerald-dark: #296d55;
+  --bill-emerald-border: rgba(203, 255, 234, 0.55);
+  --bill-teal: #4aa5c9;
+  --bill-teal-dark: #1f5b72;
+  --bill-teal-border: rgba(196, 242, 255, 0.55);
   --baseH: 960px;
-  --safe: 10px;
-  --r-xl: 26px;
-  --r-lg: 20px;
-  --r-md: 14px;
-  --r-sm: 10px;
-  --gap: 18px;
-  --pad: 20px;
+  --safe: 12px;
+  --r-xl: 28px;
+  --r-lg: 22px;
+  --r-md: 16px;
+  --r-sm: 12px;
+  --gap: 20px;
+  --pad: 22px;
   --h1: 44px;
   --h2: 30px;
   --h3: 22px;
-  --meta: 17px;
+  --meta: 16px;
   --tile: 26px;
   --chip: 18px;
 }
@@ -46,8 +62,9 @@ body {
   font-family: -apple-system, "SF Pro Text", Inter, system-ui, sans-serif;
   color: var(--text);
   background:
-    radial-gradient(1200px 650px at 15% -10%, rgba(255, 213, 74, 0.12), transparent 60%),
-    linear-gradient(#0a0f17, #0b1018);
+    radial-gradient(1200px 650px at 15% -10%, rgba(244, 182, 64, 0.08), transparent 55%),
+    radial-gradient(900px 520px at 90% 120%, rgba(75, 167, 255, 0.1), transparent 65%),
+    linear-gradient(180deg, #03060a 0%, #060a11 48%, #05090f 100%);
   padding:
     calc(env(safe-area-inset-top) + var(--safe))
     calc(env(safe-area-inset-right) + var(--safe))
@@ -79,15 +96,17 @@ body {
   display: grid;
   gap: var(--gap);
   background: var(--panel2);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(86, 115, 156, 0.28);
   border-radius: var(--r-xl);
   padding: calc(var(--gap) + 6px);
+  backdrop-filter: blur(18px);
 }
 
 .app-header {
   display: grid;
   gap: var(--gap);
   align-items: center;
+  grid-template-columns: auto 1fr auto;
 }
 
 .brand {
@@ -97,11 +116,12 @@ body {
   font-weight: 900;
   font-size: var(--h1);
   letter-spacing: 0.02em;
+  color: var(--muted-strong);
 }
 
 .badge {
-  background: var(--accent);
-  color: #0c0f14;
+  background: linear-gradient(160deg, rgba(244, 182, 64, 0.95), rgba(255, 221, 146, 0.9));
+  color: #0c1118;
   border-radius: 999px;
   padding: 6px 14px;
   font-weight: 900;
@@ -116,11 +136,12 @@ body {
 
 .card {
   background: var(--panel);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(86, 115, 156, 0.32);
   border-radius: var(--r-lg);
   padding: var(--pad);
   display: grid;
   gap: 12px;
+  box-shadow: 0 22px 44px rgba(4, 8, 14, 0.45);
 }
 
 .row {
@@ -146,6 +167,8 @@ button {
   padding: 12px 16px;
   font-weight: 900;
   font-family: inherit;
+  transition: transform 0.12s ease, filter 0.18s ease, box-shadow 0.18s ease;
+  transform-origin: center;
 }
 
 button.primary {
@@ -158,6 +181,10 @@ button.secondary {
   background: #0f1828;
   color: #fff;
   border: 1px solid var(--border);
+}
+
+button:active {
+  transform: scale(1.03);
 }
 
 h1,

--- a/styles/game.css
+++ b/styles/game.css
@@ -1,29 +1,31 @@
 .game-app {
-  grid-template-rows: 84px 120px 1fr 200px 150px;
+  grid-template-rows: minmax(88px, auto) minmax(120px, auto) 1fr minmax(220px, min(32vh, 260px)) minmax(160px, min(26vh, 220px));
 }
 
 .game-app .app-header {
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: auto 1fr auto;
+  gap: clamp(12px, 2vw, 24px);
 }
 
 .timer {
   font-weight: 900;
   font-size: var(--h2);
-  background: var(--accent);
-  color: #0c0f14;
-  padding: 10px 16px;
-  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(244, 182, 64, 0.95), rgba(244, 182, 64, 0.7));
+  color: #0c1118;
+  padding: 12px 20px;
+  border-radius: 18px;
   text-align: center;
+  box-shadow: 0 16px 36px rgba(8, 12, 18, 0.45);
 }
 
 .big {
-  font-size: var(--h2);
+  font-size: clamp(26px, 2.8vw, var(--h2));
   font-weight: 900;
 }
 
 .hud {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--gap);
 }
 
@@ -31,15 +33,17 @@
 .pay,
 .footer {
   background: var(--panel);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(86, 115, 156, 0.32);
   border-radius: var(--r-lg);
   padding: var(--pad);
   display: grid;
   gap: var(--gap);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 16px 36px rgba(5, 10, 16, 0.55);
 }
 
 .tickets {
-  grid-template-rows: 46px 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: clamp(240px, 34vh, 320px);
 }
 
 .tbar,
@@ -47,110 +51,271 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
 }
 
 .clear {
-  border: 1px solid var(--border);
-  background: #0f1828;
-  color: #eaf1ff;
-  border-radius: 12px;
-  padding: 10px 14px;
+  border: 1px solid rgba(132, 168, 214, 0.35);
+  background: var(--panel-soft);
+  color: var(--muted-strong);
+  border-radius: 14px;
+  padding: 10px 16px;
   font-weight: 800;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.clear:active,
+.clear:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .gridTickets {
   display: grid;
   gap: var(--gap);
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: minmax(120px, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  align-content: start;
 }
 
 .gridCoins {
   display: grid;
   gap: var(--gap);
-  grid-template-columns: repeat(5, 1fr);
-  grid-auto-rows: minmax(110px, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  justify-items: center;
+  align-items: start;
 }
 
 .btn {
   position: relative;
   display: grid;
   place-items: center;
+  gap: 8px;
   text-align: center;
   cursor: pointer;
   user-select: none;
   height: 100%;
   border: 0;
-  border-radius: 20px;
+  border-radius: 24px;
   color: #fff;
-  padding: 14px;
-  font-weight: 900;
-  font-size: var(--tile);
+  padding: 18px;
+  font-weight: 800;
+  font-size: clamp(18px, 2vw, var(--tile));
   line-height: 1.1;
-  box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.2), 0 12px 26px rgba(0, 0, 0, 0.32);
-  transition: transform 0.06s ease, filter 0.12s ease, opacity 0.2s ease;
-  background: #1a2232;
-}
-
-.btn:active {
-  transform: translateY(1px) scale(0.99);
+  background: linear-gradient(160deg, rgba(33, 45, 66, 0.92), rgba(20, 32, 48, 0.92));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 14px 28px rgba(2, 6, 14, 0.55);
+  min-width: 140px;
+  min-height: 140px;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 .btn:disabled {
-  opacity: 0.42;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
+.btn:not(:disabled):hover {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 18px 40px rgba(2, 6, 14, 0.68);
+}
+
 .sub {
-  font-size: 20px;
-  font-weight: 800;
-  opacity: 0.97;
+  font-size: clamp(16px, 1.6vw, 20px);
+  font-weight: 700;
+  opacity: 0.9;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .bubble {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  top: 12px;
+  right: 12px;
+  background: rgba(7, 11, 17, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.22);
   padding: 4px 10px;
   border-radius: 999px;
   font-size: var(--chip);
   font-weight: 900;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
 }
 
-.t-normal { background: linear-gradient(140deg, #22c07a, #139a61); }
-.t-kid { background: linear-gradient(140deg, #4aa7ff, #2c7cff); }
-.t-luggage { background: linear-gradient(140deg, #ff9650, #ff7828); }
-.t-senior { background: linear-gradient(140deg, #b995ff, #8a6eff); }
-.t-disabled { background: linear-gradient(140deg, #ff6e9e, #e34a82); }
-.t-stroller { background: linear-gradient(140deg, #42dede, #23bbbb); }
-.t-bike { background: linear-gradient(140deg, #a2e65a, #82cf35); }
-.t-tourist { background: linear-gradient(140deg, #ff7167, #ff5348); }
+.ticket {
+  overflow: hidden;
+  border-radius: 26px;
+  padding-inline: clamp(16px, 2.5vw, 26px);
+  padding-block: clamp(16px, 2vw, 24px);
+  aspect-ratio: 1.35 / 1;
+  align-content: center;
+}
+
+.ticket::before,
+.ticket::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.ticket::before {
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background:
+    radial-gradient(circle at 0% 50%, transparent 8px, rgba(255, 255, 255, 0.18) 9px, transparent 11px) left center / 24px 100% repeat-y,
+    radial-gradient(circle at 100% 50%, transparent 8px, rgba(255, 255, 255, 0.18) 9px, transparent 11px) right center / 24px 100% repeat-y;
+  opacity: 0.6;
+}
+
+.ticket::after {
+  inset-inline: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  opacity: 0.45;
+}
+
+.ticket .ticket-icon {
+  font-size: clamp(26px, 3.2vw, 36px);
+  filter: drop-shadow(0 4px 10px rgba(5, 8, 14, 0.35));
+}
+
+.ticket .ticket-price {
+  font-size: clamp(18px, 2.2vw, 24px);
+  font-weight: 800;
+}
+
+.t-normal { background: linear-gradient(155deg, #24b378 0%, #128559 100%); }
+.t-kid { background: linear-gradient(155deg, #4ba7ff 0%, #2b6fcc 100%); }
+.t-luggage { background: linear-gradient(155deg, #ff9345 0%, #d35b16 100%); }
+.t-senior { background: linear-gradient(155deg, #b795ff 0%, #7854e3 100%); }
+.t-disabled { background: linear-gradient(155deg, #ff6991 0%, #cf3d69 100%); }
+.t-stroller { background: linear-gradient(155deg, #4ad9d9 0%, #218a9c 100%); }
+.t-bike { background: linear-gradient(155deg, #b7f169 0%, #4f9a26 100%); }
+.t-tourist { background: linear-gradient(155deg, #ff8172 0%, #cc4030 100%); }
+
+.pay {
+  min-height: clamp(200px, 32vh, 260px);
+  position: relative;
+}
+
+.pay[data-visible='false'] .remain {
+  filter: blur(4px);
+  opacity: 0.35;
+}
+
+.pay[data-visible='false']::after {
+  content: 'Tap a coin to reveal change';
+  position: absolute;
+  inset: auto 18px 18px 18px;
+  text-align: center;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.32);
+  pointer-events: none;
+}
 
 .remain {
   font-weight: 900;
-  font-size: var(--h2);
-  padding: 10px 14px;
-  border-radius: 14px;
-  background: #0f1828;
-  border: 1px solid var(--border);
-  min-width: 150px;
+  font-size: clamp(26px, 3vw, var(--h2));
+  padding: 12px 18px;
+  border-radius: 18px;
+  background: var(--panel-soft);
+  border: 1px solid rgba(132, 168, 214, 0.32);
+  min-width: 170px;
   text-align: center;
+  transition: filter 0.2s ease, opacity 0.2s ease, color 0.2s ease;
 }
 
-.coin {
-  border-radius: 999px;
-  color: var(--coinText);
-  background: radial-gradient(circle at 30% 25%, #fff5b5 0%, var(--coin) 55%, #f0c63d 100%);
-  border: 3px solid #e8bf39;
+.remain[data-state='over'] {
+  color: var(--accent);
 }
 
-.bill {
-  border-radius: 16px;
-  color: #10311d;
-  background: linear-gradient(180deg, var(--bill1), var(--bill2));
-  border: 3px solid #9fce8c;
+.remain[data-state='short'] {
+  color: var(--bad);
+}
+
+.denomination {
+  border-radius: 32px;
+  padding: clamp(18px, 2.4vw, 26px);
+  aspect-ratio: 1 / 1;
+  min-width: 118px;
+  min-height: 118px;
+  color: var(--text);
+  display: grid;
+  place-items: center;
+  gap: 4px;
+}
+
+.denomination.bill {
+  aspect-ratio: 1.65 / 1;
+  justify-items: center;
+  border-radius: 26px;
+  color: #06130e;
+  background: linear-gradient(160deg, var(--bill-emerald), var(--bill-emerald-dark));
+  border: 2px solid var(--bill-emerald-border);
+}
+
+.denomination.bill.skin-emerald {
+  background: linear-gradient(160deg, var(--bill-emerald), var(--bill-emerald-dark));
+  border-color: var(--bill-emerald-border);
+}
+
+.denomination.bill.skin-teal {
+  background: linear-gradient(160deg, var(--bill-teal), var(--bill-teal-dark));
+  border-color: var(--bill-teal-border);
+}
+
+.denomination.coin {
+  border-radius: 50%;
+  padding: clamp(14px, 2vw, 22px);
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0) 55%),
+    radial-gradient(circle at 70% 80%, rgba(0, 0, 0, 0.25), transparent 65%),
+    linear-gradient(160deg, var(--coin-brass), var(--coin-brass-dark));
+  border: 3px solid var(--coin-brass-border);
+  box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.22), 0 12px 22px rgba(0, 0, 0, 0.45);
+}
+
+.denomination.coin.skin-silver {
+  background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0) 58%),
+    radial-gradient(circle at 70% 80%, rgba(19, 28, 42, 0.25), transparent 65%),
+    linear-gradient(160deg, var(--coin-silver), var(--coin-silver-dark));
+  border-color: var(--coin-silver-border);
+}
+
+.denomination.coin.skin-copper {
+  background: radial-gradient(circle at 35% 30%, rgba(255, 211, 180, 0.68), rgba(255, 211, 180, 0) 60%),
+    radial-gradient(circle at 70% 80%, rgba(71, 32, 16, 0.32), transparent 65%),
+    linear-gradient(160deg, var(--coin-copper), var(--coin-copper-dark));
+  border-color: var(--coin-copper-border);
+}
+
+.denomination .denom-value {
+  font-size: clamp(18px, 2.1vw, 26px);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.denomination .denom-label {
+  font-size: clamp(12px, 1.3vw, 16px);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.72;
+}
+
+.denomination .denom-icon {
+  font-size: clamp(20px, 2.4vw, 30px);
+  opacity: 0.85;
+}
+
+.denomination.size-lg {
+  aspect-ratio: 1.1 / 1;
+}
+
+.denomination.size-sm {
+  min-width: 108px;
+  min-height: 108px;
+}
+
+.denomination.size-xs {
+  min-width: 96px;
+  min-height: 96px;
 }
 
 .footer {
@@ -179,8 +344,8 @@
   font-weight: 900;
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid #2a3346;
-  color: #d9e3f3;
+  border: 1px solid rgba(132, 168, 214, 0.4);
+  color: var(--muted-strong);
 }
 
 .overlay {
@@ -265,14 +430,26 @@
 
 @media (max-width: 1200px) {
   .hud {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .gridTickets {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 
   .gridCoins {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  }
+}
+
+@media (orientation: portrait) {
+  .game-app {
+    grid-template-rows: auto auto minmax(320px, 1fr) minmax(260px, 1fr) minmax(200px, 1fr);
+  }
+
+  .btn,
+  .ticket {
+    min-width: 120px;
+    min-height: 120px;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the dark flat landscape palette and spacing so HUD, safe areas, and grids stay legible on mobile
- redesign ticket/bill/coin rendering with denomination metadata, removing the 25¢ coin and prepping toggle hooks
- overhaul ticket/change RNG, delaying change reveal until the first coin and enforcing the new perfect change bonus rule

## Testing
- node - <<'NODE' (distribution sanity check)


------
https://chatgpt.com/codex/tasks/task_b_68d6fe6d254883298c87165cbe440449