### PR TITLE
feat(ui): landscape polish with aspect-ratio, clamp fonts, safe-area and unified menu

### DIFF
--- a/game.html
+++ b/game.html
@@ -6,8 +6,11 @@
   <title>Ticket Rush — PRO</title>
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <link rel="stylesheet" href="styles/tokens.css" />
+  <link rel="stylesheet" href="styles/layout.css" />
   <link rel="stylesheet" href="styles/app.css" />
   <link rel="stylesheet" href="styles/game.css" />
+  <script src="scripts/fit.js" defer></script>
   <script type="module" src="js/main.js" defer></script>
   <script type="module" src="js/screens/game.js" defer></script>
 </head>
@@ -29,9 +32,9 @@
             <div class="meta">Passenger needs</div>
             <div class="big" id="need">—</div>
           </div>
-          <div class="card">
-            <div class="meta">To pay</div>
-            <div class="big" id="pays">$0.00</div>
+          <div class="card" id="paysCard">
+            <div class="meta">Pays</div>
+            <div class="big" id="pays">—</div>
           </div>
           <div class="card">
             <div class="meta">Tickets value</div>
@@ -54,7 +57,7 @@
         <section class="pay" aria-label="Payment">
           <div class="pbar">
             <div class="meta">Change</div>
-            <div class="remain" id="remain">$0.00</div>
+            <div class="remain" id="remain">$?</div>
           </div>
           <div class="gridCoins" id="coins"></div>
         </section>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,11 @@
   <title>Ticket Rush — Menu</title>
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <link rel="stylesheet" href="styles/tokens.css" />
+  <link rel="stylesheet" href="styles/layout.css" />
   <link rel="stylesheet" href="styles/app.css" />
   <link rel="stylesheet" href="styles/menu.css" />
+  <script src="scripts/fit.js" defer></script>
   <script type="module" src="js/main.js" defer></script>
   <script type="module" src="js/screens/menu.js" defer></script>
 </head>

--- a/js/game/actions.js
+++ b/js/game/actions.js
@@ -29,6 +29,9 @@ export function addTicket(session, ticketName) {
   }
   session.selectedTickets[ticketName] = current + 1;
   session.selectedTotal = round(session.selectedTotal + ticket.price);
+  if (!session.showPays) {
+    session.showPays = true;
+  }
   logHistory(session, `Added ${ticket.name}`, `+${currency.format(ticket.price)}`);
   return true;
 }
@@ -47,6 +50,9 @@ export function removeTicket(session, ticketName) {
     delete session.selectedTickets[ticketName];
   }
   session.selectedTotal = round(session.selectedTotal - ticket.price);
+  if (session.selectedTotal <= 0) {
+    session.showPays = false;
+  }
   logHistory(session, `Removed ${ticket.name}`, `-${currency.format(ticket.price)}`);
   return true;
 }
@@ -54,6 +60,7 @@ export function removeTicket(session, ticketName) {
 export function clearTickets(session) {
   session.selectedTickets = {};
   session.selectedTotal = 0;
+  session.showPays = false;
   logHistory(session, 'Cleared tickets', '$0.00');
 }
 
@@ -62,12 +69,16 @@ export function insertCoin(session, value) {
   session.coinsUsed[roundedValue] = (session.coinsUsed[roundedValue] || 0) + 1;
   session.inserted = round(session.inserted + roundedValue);
   const formatted = currency.format(roundedValue);
-  logHistory(session, 'Inserted', `+${formatted}`);
+  if (!session.showChange) {
+    session.showChange = true;
+  }
+  logHistory(session, 'Returned', `+${formatted}`);
   return true;
 }
 
 export function resetCoins(session) {
   session.coinsUsed = {};
   session.inserted = 0;
-  logHistory(session, 'Coins returned', '$0.00');
+  session.showChange = false;
+  logHistory(session, 'Change cleared', '$0.00');
 }

--- a/js/game/constants.js
+++ b/js/game/constants.js
@@ -1,15 +1,39 @@
 export const ALL_TICKETS = [
-  { name: 'Normal', price: 1.2, className: 't-normal' },
-  { name: 'Kid', price: 0.5, className: 't-kid' },
-  { name: 'Luggage', price: 0.6, className: 't-luggage' },
-  { name: 'Senior', price: 0.8, className: 't-senior' },
-  { name: 'Disabled', price: 0.6, className: 't-disabled' },
-  { name: 'Baby Stroller', price: 0.7, className: 't-stroller' },
-  { name: 'Bike', price: 0.9, className: 't-bike' },
-  { name: 'Tourist', price: 1.5, className: 't-tourist' },
+  { name: 'Normal', price: 1.2, className: 't-normal', icon: '🧍' },
+  { name: 'Kid', price: 0.5, className: 't-kid', icon: '🧒' },
+  { name: 'Luggage', price: 0.6, className: 't-luggage', icon: '🧳' },
+  { name: 'Senior', price: 0.8, className: 't-senior', icon: '👴' },
+  { name: 'Disabled', price: 0.6, className: 't-disabled', icon: '♿' },
+  { name: 'Baby Stroller', price: 0.7, className: 't-stroller', icon: '👶' },
+  { name: 'Bike', price: 0.9, className: 't-bike', icon: '🚲' },
+  { name: 'Tourist', price: 1.5, className: 't-tourist', icon: '🧭' },
 ];
 
-export const COINS = [5, 2, 1, 0.5, 0.25, 0.1, 0.05, 0.01];
+export const DENOMINATIONS = [
+  { value: 5, type: 'bill', skin: 'emerald', label: 'Transit bill', icon: '⑤', toggleKey: 'allowFive' },
+  { value: 2, type: 'bill', skin: 'teal', label: 'Express bill', icon: '②', toggleKey: 'allowTwo' },
+  { value: 1, type: 'bill', skin: 'emerald-light', label: 'Single ride', icon: '①' },
+  { value: 0.5, type: 'coin', skin: 'silver', label: 'Half coin', icon: '◎' },
+  { value: 0.1, type: 'coin', skin: 'silver', label: 'Dime', icon: '◉' },
+  { value: 0.05, type: 'coin', skin: 'copper', label: 'Nickel', icon: '◍' },
+  { value: 0.01, type: 'coin', skin: 'copper', label: 'Penny', icon: '∙', toggleKey: 'allowOneCent' },
+];
+
+export const COIN_TOGGLES = {
+  allowFive: true,
+  allowTwo: true,
+  allowOneCent: true,
+};
+
+export function getAvailableDenominations(overrides = {}) {
+  const toggles = { ...COIN_TOGGLES, ...overrides };
+  return DENOMINATIONS.filter((item) => {
+    if (!item.toggleKey) {
+      return true;
+    }
+    return toggles[item.toggleKey] !== false;
+  });
+}
 
 export const GAME_MODES = {
   TB1: { label: 'Top/Bottom 1', timeLimit: 20, description: 'Classic rush with single passenger focus.' },

--- a/js/game/state.js
+++ b/js/game/state.js
@@ -1,4 +1,8 @@
-import { GAME_MODES, DEFAULT_MODE, TOTAL_ROUNDS } from './constants.js';
+import { GAME_MODES, DEFAULT_MODE, TOTAL_ROUNDS, COIN_TOGGLES } from './constants.js';
+
+function defaultCoinOptions() {
+  return { ...COIN_TOGGLES };
+}
 
 function resolveMode(mode) {
   if (mode && GAME_MODES[mode]) {
@@ -13,6 +17,7 @@ function baseRoundState(timeLimit) {
     request: {},
     ticketTotal: 0,
     pays: 0,
+    changeDue: 0,
     selectedTickets: {},
     selectedTotal: 0,
     coinsUsed: {},
@@ -20,6 +25,7 @@ function baseRoundState(timeLimit) {
     timeLeft: timeLimit,
     history: [],
     showChange: false,
+    showPays: false,
   };
 }
 
@@ -30,6 +36,7 @@ export const SESSION = {
   totalRounds: TOTAL_ROUNDS,
   score: 0,
   roundSummaries: [],
+  coinOptions: defaultCoinOptions(),
   ...baseRoundState(GAME_MODES[DEFAULT_MODE].timeLimit),
 };
 
@@ -44,6 +51,7 @@ export function startSession(player, mode) {
   SESSION.score = 0;
   SESSION.roundSummaries = [];
   SESSION.totalRounds = TOTAL_ROUNDS;
+  SESSION.coinOptions = defaultCoinOptions();
 
   Object.assign(SESSION, baseRoundState(timeLimit));
 
@@ -52,7 +60,8 @@ export function startSession(player, mode) {
 
 export function resetRoundState() {
   const timeLimit = GAME_MODES[SESSION.mode].timeLimit;
-  Object.assign(SESSION, baseRoundState(timeLimit));
+  const nextState = baseRoundState(timeLimit);
+  Object.assign(SESSION, nextState, { coinOptions: SESSION.coinOptions });
 }
 
 export function endSession() {

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,3 @@
-import { setupFitToStage } from './util/fit.js';
 import { preventIOSZoom } from './util/ios.js';
 
 preventIOSZoom();
-
-const stage = document.getElementById('stage');
-const viewport = document.getElementById('viewport');
-
-if (stage) {
-  setupFitToStage(stage, viewport);
-}

--- a/scripts/fit.js
+++ b/scripts/fit.js
@@ -1,0 +1,42 @@
+(() => {
+  const stage = document.getElementById('stage');
+  if (!stage) return;
+
+  const root = document.documentElement;
+  const viewport = window.visualViewport;
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  const measure = () => {
+    const vv = viewport || { width: window.innerWidth, height: window.innerHeight };
+    const height = clamp(vv.height, 540, 820);
+    const width = height * (16 / 9);
+    const scale = Math.min(vv.width / width, vv.height / height);
+
+    stage.style.width = `${width}px`;
+    stage.style.height = `${height}px`;
+    stage.style.setProperty('--fit', `${scale}`);
+    root.style.setProperty('--baseH', `${height}px`);
+    raf = null;
+  };
+
+  let raf = null;
+  const schedule = () => {
+    if (raf) cancelAnimationFrame(raf);
+    raf = requestAnimationFrame(measure);
+  };
+
+  if (viewport) {
+    viewport.addEventListener('resize', schedule, { passive: true });
+    viewport.addEventListener('scroll', schedule, { passive: true });
+  }
+
+  window.addEventListener('resize', schedule, { passive: true });
+  window.addEventListener('orientationchange', () => setTimeout(measure, 120), { passive: true });
+
+  if (document.fonts?.ready) {
+    document.fonts.ready.then(measure).catch(measure);
+  }
+
+  measure();
+})();

--- a/styles/app.css
+++ b/styles/app.css
@@ -1,172 +1,127 @@
-:root {
-  color-scheme: dark;
-  --bg: #0b1018;
-  --panel: #0e1522;
-  --panel2: #0a111c;
-  --border: #223047;
-  --text: #f3f7ff;
-  --muted: #9fb0c9;
-  --accent: #ffd54a;
-  --ok: #35d08a;
-  --bad: #ff5555;
-  --coin: #ffd54a;
-  --coinText: #1a2232;
-  --bill1: #d6f0c9;
-  --bill2: #b8e3aa;
-  --baseH: 960px;
-  --safe: 10px;
-  --r-xl: 26px;
-  --r-lg: 20px;
-  --r-md: 14px;
-  --r-sm: 10px;
-  --gap: 18px;
-  --pad: 20px;
-  --h1: 44px;
-  --h2: 30px;
-  --h3: 22px;
-  --meta: 17px;
-  --tile: 26px;
-  --chip: 18px;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html {
-  height: 100dvh;
-  -webkit-text-size-adjust: 100%;
-}
-
-body {
-  margin: 0;
-  height: 100dvh;
-  overflow: hidden;
-  touch-action: manipulation;
-  font-family: -apple-system, "SF Pro Text", Inter, system-ui, sans-serif;
-  color: var(--text);
-  background:
-    radial-gradient(1200px 650px at 15% -10%, rgba(255, 213, 74, 0.12), transparent 60%),
-    linear-gradient(#0a0f17, #0b1018);
-  padding:
-    calc(env(safe-area-inset-top) + var(--safe))
-    calc(env(safe-area-inset-right) + var(--safe))
-    calc(env(safe-area-inset-bottom) + var(--safe))
-    calc(env(safe-area-inset-left) + var(--safe));
-  -webkit-tap-highlight-color: transparent;
-}
-
-#viewport {
-  position: fixed;
-  inset: 0;
-  overflow: hidden;
-}
-
-#stage {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: calc(var(--baseH) * (16 / 9));
-  height: var(--baseH);
-  transform: translate(-50%, -50%) scale(var(--fit, 1));
-  transform-origin: center;
-  filter: drop-shadow(0 22px 50px rgba(0, 0, 0, 0.44));
-}
-
 .app {
   width: 100%;
   height: 100%;
   display: grid;
-  gap: var(--gap);
-  background: var(--panel2);
-  border: 1px solid var(--border);
-  border-radius: var(--r-xl);
-  padding: calc(var(--gap) + 6px);
+  gap: var(--space-lg);
+  padding: calc(var(--space-lg) + var(--space-sm));
+  background: var(--panel);
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(34, 48, 71, 0.65);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
 }
 
 .app-header {
   display: grid;
-  gap: var(--gap);
+  gap: var(--space-lg);
+  grid-template-columns: auto 1fr auto;
   align-items: center;
 }
 
 .brand {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 14px;
+  gap: var(--space-sm);
   font-weight: 900;
   font-size: var(--h1);
   letter-spacing: 0.02em;
+  color: var(--muted-strong);
 }
 
 .badge {
-  background: var(--accent);
-  color: #0c0f14;
-  border-radius: 999px;
   padding: 6px 14px;
-  font-weight: 900;
+  border-radius: 999px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  background: linear-gradient(150deg, rgba(255, 213, 74, 0.95), rgba(255, 213, 74, 0.75));
+  color: #0b0f16;
 }
 
 .meta {
-  color: var(--muted);
   font-size: var(--meta);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+  color: var(--muted);
 }
 
 .card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  padding: var(--pad);
   display: grid;
-  gap: 12px;
-}
-
-.row {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  align-items: center;
+  gap: var(--space-sm);
+  padding: clamp(16px, 2.8vmin, 24px);
+  background: var(--panelAlt);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(34, 48, 71, 0.55);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 16px 34px rgba(4, 9, 16, 0.45);
 }
 
 input,
 select {
-  background: #0f1828;
-  border: 1px solid var(--border);
-  color: #fff;
-  padding: 10px 12px;
-  border-radius: 10px;
-  font-size: 16px;
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(62, 87, 122, 0.6);
+  background: var(--panelSoft);
+  color: var(--text);
+  font-size: clamp(16px, 2vmin, 22px);
 }
 
-button {
-  cursor: pointer;
-  border-radius: 12px;
-  padding: 12px 16px;
-  font-weight: 900;
-  font-family: inherit;
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid rgba(255, 213, 74, 0.55);
+  outline-offset: 2px;
+}
+
+.btn,
+button.primary,
+button.secondary {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
+  font-weight: 800;
+  font-size: clamp(16px, 2.1vmin, 22px);
+  text-transform: none;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+  color: var(--text);
+  background: var(--panelRaised);
+  border: 1px solid rgba(62, 87, 122, 0.65);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 12px 26px rgba(4, 9, 16, 0.45);
 }
 
 button.primary {
-  background: var(--accent);
-  color: #0c0f14;
-  border: 0;
+  background: linear-gradient(145deg, var(--accent), var(--accent-muted));
+  color: #0b0f16;
+  border: none;
+  box-shadow: 0 16px 34px rgba(255, 213, 74, 0.3);
 }
 
 button.secondary {
-  background: #0f1828;
-  color: #fff;
-  border: 1px solid var(--border);
+  background: var(--panelSoft);
 }
 
-h1,
-h2,
-h3,
-p {
-  margin: 0;
+.btn:active,
+button.primary:active,
+button.secondary:active {
+  transform: translateY(1px) scale(0.985);
 }
 
-.hidden {
-  display: none !important;
+.btn:focus-visible,
+button.primary:focus-visible,
+button.secondary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.menu-app,
+.game-app {
+  width: 100%;
+  height: 100%;
 }

--- a/styles/game.css
+++ b/styles/game.css
@@ -1,45 +1,56 @@
 .game-app {
-  grid-template-rows: 84px 120px 1fr 200px 150px;
+  display: grid;
+  grid-template-rows: auto auto 1fr auto auto;
+  gap: var(--space-lg);
 }
 
 .game-app .app-header {
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: auto 1fr auto;
 }
 
 .timer {
+  padding: 10px 18px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(155deg, rgba(255, 213, 74, 0.92), rgba(255, 213, 74, 0.72));
+  color: #0c1118;
   font-weight: 900;
   font-size: var(--h2);
-  background: var(--accent);
-  color: #0c0f14;
-  padding: 10px 16px;
-  border-radius: 14px;
+  min-width: 92px;
   text-align: center;
+  box-shadow: 0 16px 36px rgba(8, 12, 18, 0.45);
 }
 
 .big {
-  font-size: var(--h2);
+  font-size: clamp(26px, 3vmin, 34px);
   font-weight: 900;
+  line-height: 1.1;
+}
+
+.card.is-muted {
+  opacity: 0.55;
 }
 
 .hud {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
-  gap: var(--gap);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-lg);
 }
 
 .tickets,
 .pay,
 .footer {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  padding: var(--pad);
   display: grid;
-  gap: var(--gap);
+  gap: var(--space-lg);
+  padding: clamp(18px, 2.6vmin, 26px);
+  background: var(--panelAlt);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(34, 48, 71, 0.55);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 16px 34px rgba(4, 9, 16, 0.45);
 }
 
 .tickets {
-  grid-template-rows: 46px 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: clamp(260px, 36vh, 320px);
 }
 
 .tbar,
@@ -47,140 +58,300 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--space-md);
 }
 
 .clear {
-  border: 1px solid var(--border);
-  background: #0f1828;
-  color: #eaf1ff;
-  border-radius: 12px;
-  padding: 10px 14px;
-  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(62, 87, 122, 0.55);
+  background: var(--panelSoft);
+  color: var(--muted-strong);
+  font-weight: 700;
+  font-size: clamp(14px, 1.9vmin, 18px);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.clear:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.clear:active {
+  transform: translateY(1px) scale(0.985);
 }
 
 .gridTickets {
   display: grid;
-  gap: var(--gap);
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: minmax(120px, 1fr);
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-content: start;
+}
+
+.ticket-btn {
+  position: relative;
+  display: grid;
+  gap: var(--space-sm);
+  justify-items: center;
+  align-content: center;
+  text-align: center;
+  color: var(--text);
+  font-weight: 800;
+  font-size: var(--tileText);
+  width: 100%;
+  aspect-ratio: 16 / 11;
+  min-height: 120px;
+  padding: clamp(16px, 2.4vmin, 26px);
+  border-radius: 26px;
+  overflow: hidden;
+  background: linear-gradient(155deg, rgba(33, 45, 66, 0.92), rgba(20, 32, 48, 0.92));
+  border: 1px solid rgba(34, 48, 71, 0.55);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 18px 36px rgba(2, 6, 14, 0.58);
+}
+
+.ticket-btn .sub {
+  font-size: clamp(14px, 2vmin, 20px);
+  letter-spacing: 0.02em;
+}
+
+.ticket-btn .ticket-icon {
+  font-size: clamp(28px, 4vmin, 40px);
+  filter: drop-shadow(0 6px 12px rgba(5, 8, 14, 0.45));
+}
+
+.ticket-btn .ticket-price {
+  font-size: clamp(18px, 2.4vmin, 26px);
+}
+
+.ticket-btn .bubble {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: clamp(14px, 1.8vmin, 18px);
+  font-weight: 800;
+  background: rgba(7, 11, 17, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.ticket-btn.ticket::before,
+.ticket-btn.ticket::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 20px;
+  pointer-events: none;
+}
+
+.ticket-btn.ticket::before {
+  border: 1px dashed rgba(255, 255, 255, 0.22);
+  opacity: 0.5;
+}
+
+.ticket-btn.ticket::after {
+  inset-inline: clamp(12px, 2.4vmin, 20px);
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  opacity: 0.35;
+}
+
+.ticket-btn.t-normal { background: var(--ticket-normal); }
+.ticket-btn.t-kid { background: var(--ticket-kid); }
+.ticket-btn.t-luggage { background: var(--ticket-luggage); }
+.ticket-btn.t-senior { background: var(--ticket-senior); }
+.ticket-btn.t-disabled { background: var(--ticket-disabled); }
+.ticket-btn.t-stroller { background: var(--ticket-stroller); }
+.ticket-btn.t-bike { background: var(--ticket-bike); }
+.ticket-btn.t-tourist { background: var(--ticket-tourist); }
+
+.ticket-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ticket-btn:not(:disabled):hover {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 22px 40px rgba(2, 6, 14, 0.68);
+}
+
+.pay {
+  min-height: clamp(220px, 34vh, 280px);
+  position: relative;
+}
+
+.pay[data-visible='false'] .remain {
+  opacity: 0.4;
+  filter: blur(3px);
+}
+
+.pay[data-visible='false'][data-mode='waiting']::after {
+  content: 'Tap a coin to reveal change';
+  position: absolute;
+  inset: auto 18px 18px 18px;
+  text-align: center;
+  font-size: clamp(12px, 1.8vmin, 16px);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.28);
+  pointer-events: none;
+}
+
+.pay[data-visible='false'][data-mode='exact']::after {
+  content: 'Exact fare — no change needed';
+  position: absolute;
+  inset: auto 18px 18px 18px;
+  text-align: center;
+  font-size: clamp(12px, 1.8vmin, 16px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.32);
+  pointer-events: none;
 }
 
 .gridCoins {
   display: grid;
-  gap: var(--gap);
-  grid-template-columns: repeat(5, 1fr);
-  grid-auto-rows: minmax(110px, 1fr);
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  align-items: start;
 }
 
-.btn {
-  position: relative;
+.currency-btn {
   display: grid;
-  place-items: center;
-  text-align: center;
-  cursor: pointer;
-  user-select: none;
-  height: 100%;
-  border: 0;
-  border-radius: 20px;
-  color: #fff;
-  padding: 14px;
-  font-weight: 900;
-  font-size: var(--tile);
-  line-height: 1.1;
-  box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.2), 0 12px 26px rgba(0, 0, 0, 0.32);
-  transition: transform 0.06s ease, filter 0.12s ease, opacity 0.2s ease;
-  background: #1a2232;
-}
-
-.btn:active {
-  transform: translateY(1px) scale(0.99);
-}
-
-.btn:disabled {
-  opacity: 0.42;
-  cursor: not-allowed;
-}
-
-.sub {
-  font-size: 20px;
+  gap: var(--space-xs);
+  justify-items: center;
+  align-content: center;
+  color: var(--text);
   font-weight: 800;
-  opacity: 0.97;
+  font-size: clamp(16px, 2.2vmin, 24px);
+  padding: clamp(14px, 2.4vmin, 22px);
+  width: 100%;
+  min-height: 120px;
+  box-shadow: 0 16px 34px rgba(3, 6, 12, 0.55);
+  border: 2px solid rgba(34, 48, 71, 0.4);
 }
 
-.bubble {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-size: var(--chip);
-  font-weight: 900;
+.currency-btn .denom-value {
+  font-weight: 800;
 }
 
-.t-normal { background: linear-gradient(140deg, #22c07a, #139a61); }
-.t-kid { background: linear-gradient(140deg, #4aa7ff, #2c7cff); }
-.t-luggage { background: linear-gradient(140deg, #ff9650, #ff7828); }
-.t-senior { background: linear-gradient(140deg, #b995ff, #8a6eff); }
-.t-disabled { background: linear-gradient(140deg, #ff6e9e, #e34a82); }
-.t-stroller { background: linear-gradient(140deg, #42dede, #23bbbb); }
-.t-bike { background: linear-gradient(140deg, #a2e65a, #82cf35); }
-.t-tourist { background: linear-gradient(140deg, #ff7167, #ff5348); }
+.currency-btn .denom-label {
+  font-size: clamp(12px, 1.9vmin, 16px);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.currency-btn .denom-icon {
+  font-size: clamp(20px, 2.6vmin, 30px);
+  opacity: 0.85;
+}
+
+.currency-btn.coin {
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background:
+    var(--coin-highlight),
+    var(--coin-shadow),
+    var(--coin-brass);
+  border-color: rgba(200, 162, 74, 0.65);
+}
+
+.currency-btn.coin.skin-silver {
+  background:
+    radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.75), transparent 58%),
+    radial-gradient(circle at 70% 78%, rgba(12, 18, 26, 0.32), transparent 62%),
+    var(--coin-silver);
+  border-color: rgba(166, 180, 203, 0.65);
+}
+
+.currency-btn.coin.skin-copper {
+  background:
+    radial-gradient(circle at 32% 28%, rgba(255, 223, 203, 0.65), transparent 58%),
+    radial-gradient(circle at 70% 78%, rgba(46, 22, 11, 0.32), transparent 62%),
+    var(--coin-copper);
+  border-color: rgba(205, 143, 93, 0.65);
+}
+
+.currency-btn.bill {
+  aspect-ratio: 7 / 4;
+  border-radius: 18px;
+  background: var(--bill-emerald);
+  color: #07160f;
+  border-color: var(--bill-border);
+}
+
+.currency-btn.bill.skin-teal {
+  background: var(--bill-teal);
+  border-color: var(--bill-border-alt);
+}
+
+.currency-btn.bill.skin-emerald {
+  background: var(--bill-emerald);
+  border-color: var(--bill-border);
+}
+
+.currency-btn.bill.skin-emerald-light {
+  background: var(--bill-emerald-light);
+  border-color: var(--bill-border-light);
+}
+
+.currency-btn:active {
+  transform: translateY(1px) scale(0.985);
+}
 
 .remain {
-  font-weight: 900;
-  font-size: var(--h2);
-  padding: 10px 14px;
-  border-radius: 14px;
-  background: #0f1828;
-  border: 1px solid var(--border);
-  min-width: 150px;
+  padding: 12px 18px;
+  border-radius: var(--radius-md);
+  background: var(--panelSoft);
+  border: 1px solid rgba(62, 87, 122, 0.55);
+  font-size: clamp(24px, 3vmin, 30px);
+  font-weight: 800;
+  min-width: 170px;
   text-align: center;
+  transition: filter 0.2s ease, opacity 0.2s ease, color 0.2s ease;
 }
 
-.coin {
-  border-radius: 999px;
-  color: var(--coinText);
-  background: radial-gradient(circle at 30% 25%, #fff5b5 0%, var(--coin) 55%, #f0c63d 100%);
-  border: 3px solid #e8bf39;
+.remain[data-state='over'] {
+  color: var(--accent);
 }
 
-.bill {
-  border-radius: 16px;
-  color: #10311d;
-  background: linear-gradient(180deg, var(--bill1), var(--bill2));
-  border: 3px solid #9fce8c;
+.remain[data-state='short'] {
+  color: var(--bad);
 }
 
 .footer {
-  grid-template-rows: 22px 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: clamp(160px, 24vh, 220px);
 }
 
 .list {
   display: grid;
-  gap: 12px;
+  gap: var(--space-sm);
   grid-auto-rows: minmax(48px, auto);
   overflow: auto;
+  padding-right: 6px;
 }
 
 .item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 12px;
-  border-radius: 12px;
-  background: #0b1220;
-  border: 1px solid var(--border);
-  font-size: 16px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: var(--panelSoft);
+  border: 1px solid rgba(34, 48, 71, 0.45);
+  font-size: clamp(14px, 1.9vmin, 18px);
+  gap: var(--space-md);
 }
 
 .history-label {
-  font-weight: 900;
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid #2a3346;
-  color: #d9e3f3;
+  border: 1px solid rgba(62, 87, 122, 0.5);
+  color: var(--muted-strong);
+  font-weight: 700;
 }
 
 .overlay {
@@ -188,7 +359,7 @@
   inset: 0;
   display: none;
   place-items: center;
-  background: rgba(8, 12, 20, 0.7);
+  background: rgba(8, 12, 20, 0.72);
   backdrop-filter: blur(6px);
   z-index: 20;
 }
@@ -198,81 +369,62 @@
 }
 
 .box {
-  background: #0b1220;
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  padding: 28px 32px;
-  text-align: center;
-  width: min(92vw, 800px);
+  background: var(--panelAlt);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(34, 48, 71, 0.55);
+  padding: clamp(22px, 3vmin, 32px);
+  width: min(92vw, 780px);
   display: grid;
-  gap: 18px;
+  gap: var(--space-md);
+  text-align: center;
 }
 
 .title {
-  font-size: 38px;
+  font-size: clamp(28px, 4vmin, 38px);
   font-weight: 900;
-  margin-bottom: 4px;
-}
-
-.count {
-  font-size: 32px;
-  font-weight: 900;
-  color: var(--accent);
 }
 
 .small {
   color: var(--muted);
-  font-size: 18px;
+  font-size: clamp(14px, 2vmin, 20px);
 }
 
 .points {
-  font-size: 34px;
+  font-size: clamp(24px, 3.2vmin, 36px);
   font-weight: 900;
 }
 
-.good { color: var(--ok); }
-.bad { color: var(--bad); }
+.good {
+  color: var(--ok);
+}
+
+.bad {
+  color: var(--bad);
+}
 
 .summary-list {
   display: grid;
-  gap: 10px;
-  margin-top: 14px;
-  max-height: 52vh;
-  overflow: auto;
-  text-align: left;
+  gap: var(--space-sm);
 }
 
 .s-item {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  padding: 10px 12px;
-  border-radius: 12px;
-  background: #0b1220;
-  border: 1px solid var(--border);
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: clamp(14px, 1.9vmin, 18px);
 }
 
 .btn-cta {
-  margin-top: 18px;
   padding: 12px 18px;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: #0f1828;
-  color: #fff;
-  font-weight: 900;
-  cursor: pointer;
+  border-radius: var(--radius-md);
+  font-weight: 800;
+  background: var(--panelRaised);
+  border: 1px solid rgba(62, 87, 122, 0.65);
+  color: var(--text);
 }
 
-@media (max-width: 1200px) {
-  .hud {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .gridTickets {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .gridCoins {
-    grid-template-columns: repeat(3, 1fr);
-  }
+.btn-cta:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -1,0 +1,72 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  height: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif;
+  background:
+    radial-gradient(1200px 640px at 12% -10%, rgba(255, 213, 74, 0.08), transparent 65%),
+    radial-gradient(920px 540px at 88% 120%, rgba(41, 91, 122, 0.1), transparent 68%),
+    linear-gradient(180deg, #070c15 0%, #050a12 48%, #04070d 100%);
+  color: var(--text);
+  padding:
+    calc(env(safe-area-inset-top) + var(--safe))
+    calc(env(safe-area-inset-right) + var(--safe))
+    calc(env(safe-area-inset-bottom) + var(--safe))
+    calc(env(safe-area-inset-left) + var(--safe));
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#viewport {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+#stage {
+  position: relative;
+  width: calc(var(--baseH) * (16 / 9));
+  height: var(--baseH);
+  transform: scale(var(--fit, 1));
+  transform-origin: center;
+  filter: drop-shadow(0 22px 48px rgba(0, 0, 0, 0.55));
+  pointer-events: auto;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  border: 0;
+  background: none;
+}
+
+.hidden {
+  display: none !important;
+}

--- a/styles/menu.css
+++ b/styles/menu.css
@@ -1,43 +1,49 @@
 .menu-app {
+  display: grid;
   grid-template-rows: auto 1fr;
   align-content: start;
+  gap: var(--space-lg);
 }
 
 .menu-app .app-header {
   grid-template-columns: 1fr;
 }
 
-.menu-app .card {
-  gap: 16px;
-}
-
 .menu-form {
   display: grid;
-  gap: var(--gap);
+  gap: var(--space-lg);
 }
 
-.menu-form .row {
-  justify-content: space-between;
+.menu-form .card {
+  gap: var(--space-md);
 }
 
 .menu-form label {
   display: grid;
-  gap: 8px;
+  gap: var(--space-xs);
   font-weight: 700;
+  font-size: clamp(16px, 2.2vmin, 22px);
+  color: var(--muted-strong);
+}
+
+.menu-form .row {
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
 }
 
 .menu-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 12px;
+  gap: var(--space-md);
 }
 
-@media (max-width: 900px) {
-  .menu-form .row {
-    flex-direction: column;
-    align-items: stretch;
-  }
+.menu-actions button {
+  min-height: 44px;
+  min-width: 160px;
+}
 
+@media (max-width: 980px) {
   .menu-actions {
     justify-content: stretch;
   }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,61 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b1018;
+  --panel: #0e1522;
+  --panelAlt: #0a111c;
+  --panelSoft: #111a29;
+  --panelRaised: #141f32;
+  --border: #223047;
+  --borderSoft: rgba(62, 87, 122, 0.6);
+  --borderGlow: rgba(255, 213, 74, 0.3);
+  --text: #f3f7ff;
+  --muted: #9fb0c9;
+  --muted-strong: #d4ddf0;
+  --accent: #ffd54a;
+  --accent-muted: #e9b73a;
+  --ok: #5fddaf;
+  --bad: #ff6f7d;
+  --info: #73b7ff;
+  --safe: 8px;
+  --baseH: 640px;
+  --fit: 1;
+
+  --ticket-normal: linear-gradient(155deg, #1b7a53 0%, #29a06b 100%);
+  --ticket-kid: linear-gradient(155deg, #1f5ba9 0%, #3f8de0 100%);
+  --ticket-luggage: linear-gradient(155deg, #a15b1f 0%, #d77a34 100%);
+  --ticket-senior: linear-gradient(155deg, #6a52c7 0%, #8d73f0 100%);
+  --ticket-disabled: linear-gradient(155deg, #8f2f63 0%, #c74a88 100%);
+  --ticket-stroller: linear-gradient(155deg, #167d88 0%, #2bb2be 100%);
+  --ticket-bike: linear-gradient(155deg, #3b7227 0%, #5c9b39 100%);
+  --ticket-tourist: linear-gradient(155deg, #a3473b 0%, #d06252 100%);
+
+  --coin-brass: linear-gradient(160deg, #c89c3d 0%, #9b7526 100%);
+  --coin-silver: linear-gradient(160deg, #d7dce8 0%, #949bb1 100%);
+  --coin-copper: linear-gradient(160deg, #e7a167 0%, #af6b32 100%);
+  --coin-highlight: radial-gradient(circle at 32% 28%, rgba(255, 249, 236, 0.65), transparent 55%);
+  --coin-shadow: radial-gradient(circle at 70% 78%, rgba(12, 18, 26, 0.32), transparent 62%);
+  --bill-emerald: linear-gradient(160deg, #71c0a1 0%, #2b6f56 100%);
+  --bill-teal: linear-gradient(160deg, #4aa5c9 0%, #1f5b72 100%);
+  --bill-emerald-light: linear-gradient(160deg, #8cd1b2 0%, #357b5f 100%);
+  --bill-border: rgba(143, 207, 184, 0.5);
+  --bill-border-alt: rgba(142, 209, 231, 0.45);
+  --bill-border-light: rgba(178, 230, 206, 0.45);
+
+  --radius-xl: 28px;
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 22px 44px rgba(5, 9, 18, 0.55);
+  --shadow-glow: 0 0 0 1px rgba(255, 213, 74, 0.18), 0 12px 32px rgba(0, 0, 0, 0.4);
+
+  --space-xs: 6px;
+  --space-sm: 10px;
+  --space-md: 16px;
+  --space-lg: 20px;
+  --space-xl: 28px;
+
+  --h1: clamp(24px, 3.2vmin, 40px);
+  --h2: clamp(18px, 2.4vmin, 28px);
+  --tileText: clamp(16px, 2.2vmin, 24px);
+  --meta: clamp(12px, 1.8vmin, 18px);
+}


### PR DESCRIPTION
## Summary
- introduce shared tokens/layout styles and a viewport-height fit script so menu and game scale consistently in landscape with safe-area padding
- restyle tickets, bills and coins with aspect-ratio enforcement, clamp-based typography and refreshed dark palette for better mobile legibility
- adjust round flow so Pays stays muted until tickets are chosen and Change remains hidden until the first coin tap, including zero-change guidance messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d6fe6d254883298c87165cbe440449