### PR TITLE
Rework landscape layout for Ticket Rush screens

### DIFF
--- a/game.html
+++ b/game.html
@@ -25,7 +25,10 @@
         <span class="label">Score</span>
         <span class="value" id="score">0</span>
       </div>
-      <div class="timer" id="timer" aria-live="polite">20 s</div>
+      <div class="stat-card timer-card" aria-live="polite">
+        <span class="label">Timer</span>
+        <span class="timer" id="timer">20 s</span>
+      </div>
     </header>
 
     <section class="info-panels" aria-live="polite">

--- a/js/game/constants.js
+++ b/js/game/constants.js
@@ -10,17 +10,15 @@ export const ALL_TICKETS = [
 ];
 
 export const DENOMINATIONS = [
-  { value: 5, type: 'bill', skin: 'emerald', label: 'Transit bill', icon: '⑤', toggleKey: 'allowFive' },
-  { value: 2, type: 'bill', skin: 'teal', label: 'Express bill', icon: '②', toggleKey: 'allowTwo' },
-  { value: 1, type: 'bill', skin: 'emerald-light', label: 'Single ride', icon: '①' },
+  { value: 2, type: 'coin', skin: 'blue', label: 'Express coin', icon: '②', toggleKey: 'allowTwo' },
+  { value: 1, type: 'coin', skin: 'gold', label: 'Dollar coin', icon: '①' },
   { value: 0.5, type: 'coin', skin: 'silver', label: 'Half coin', icon: '◎' },
-  { value: 0.1, type: 'coin', skin: 'silver', label: 'Dime', icon: '◉' },
-  { value: 0.05, type: 'coin', skin: 'copper', label: 'Nickel', icon: '◍' },
-  { value: 0.01, type: 'coin', skin: 'copper', label: 'Penny', icon: '∙', toggleKey: 'allowOneCent' },
+  { value: 0.1, type: 'coin', skin: 'bronze', label: 'Dime', icon: '◉' },
+  { value: 0.05, type: 'coin', skin: 'bronze-dark', label: 'Nickel', icon: '◍' },
+  { value: 0.01, type: 'coin', skin: 'bronze-soft', label: 'Penny', icon: '∙', toggleKey: 'allowOneCent' },
 ];
 
 export const COIN_TOGGLES = {
-  allowFive: true,
   allowTwo: true,
   allowOneCent: true,
 };

--- a/menu.html
+++ b/menu.html
@@ -12,19 +12,17 @@
 </head>
 <body class="app-body">
   <main class="app-screen menu-screen" role="main">
-    <header class="top-bar menu-bar">
-      <div class="brand">
-        <span class="logo" aria-hidden="true">🚌</span>
-        <div class="brand-text">
-          <span class="title">Ticket Rush PRO</span>
-          <span class="subtitle">Ticket counter training</span>
-        </div>
-      </div>
+    <header class="menu-header">
+      <span class="logo" aria-hidden="true">🚌</span>
+      <h1 class="menu-title">Ticket Rush PRO</h1>
+      <p class="menu-subtitle">Ticket counter training</p>
     </header>
 
-    <section class="menu-intro">
-      <h1 class="headline">Ready for the rush?</h1>
-      <p class="lead">Set your details below and jump straight into the ticket booth.</p>
+    <section class="menu-hero">
+      <div>
+        <h2>Ready for the rush?</h2>
+        <p class="menu-copy">Enter your details, pick a mode, and jump straight into the booth.</p>
+      </div>
     </section>
 
     <form class="menu-form" aria-label="Start a new game" onsubmit="return false;">

--- a/styles/app.css
+++ b/styles/app.css
@@ -1,23 +1,21 @@
 :root {
   color-scheme: dark;
   --bg: #101820;
-  --surface: #182430;
-  --surface-raised: #1f2d3a;
-  --surface-strong: #243548;
-  --surface-soft: #1a2734;
-  --text-primary: #f4f8ff;
-  --text-muted: #98a8bb;
+  --surface: #172330;
+  --surface-subtle: #1c2a38;
+  --surface-strong: #233445;
+  --overlay: rgba(5, 9, 14, 0.82);
+  --text-primary: #f4f7fb;
+  --text-muted: #92a4b8;
   --accent: #ffd166;
-  --accent-dark: #6c4d17;
-  --danger: #ff6f6f;
-  --radius-md: clamp(14px, 2.4vw, 22px);
-  --radius-lg: clamp(18px, 3vw, 28px);
-  --shadow-soft: 0 1.2vmin 2.4vmin rgba(0, 0, 0, 0.35);
-  --font-base: clamp(14px, 1.9vw, 18px);
-  --font-sm: clamp(12px, 1.6vw, 16px);
-  --font-lg: clamp(18px, 2.6vw, 26px);
-  --font-xl: clamp(22px, 3.6vw, 40px);
-  --font-xxl: clamp(32px, 6vw, 56px);
+  --shadow-soft: 0 0.8vh 2.2vh rgba(0, 0, 0, 0.38);
+  --radius-sm: clamp(10px, 0.8vw, 14px);
+  --radius-md: clamp(14px, 1.2vw, 18px);
+  --radius-lg: clamp(18px, 1.8vw, 26px);
+  --font-base: clamp(14px, 2vw, 22px);
+  --font-heading: clamp(20px, 3.2vw, 34px);
+  --font-display: clamp(28px, 4vw, 46px);
+  --font-huge: clamp(36px, 5.2vw, 60px);
 }
 
 *,
@@ -28,17 +26,18 @@
 
 html,
 body {
-  width: 100%;
   height: 100%;
+  width: 100%;
+  overflow: hidden;
 }
 
 body {
   margin: 0;
-  font-family: 'SF Pro Display', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: var(--font-base);
   line-height: 1.4;
-  background: var(--bg);
   color: var(--text-primary);
+  background: var(--bg);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -48,178 +47,175 @@ body,
 }
 
 .app-body {
-  min-height: 100vh;
   min-width: 100vw;
+  min-height: 100vh;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
 }
 
 .app-screen {
   width: 100vw;
-  min-height: 100vh;
+  height: 100vh;
+  padding: clamp(12px, 3vh, 24px) clamp(16px, 4vw, 32px);
+  background: var(--bg);
   display: flex;
   flex-direction: column;
-  gap: clamp(16px, 3vh, 32px);
-  padding: clamp(20px, 4vh, 40px) clamp(20px, 5vw, 56px);
-  background: radial-gradient(120vw 120vh at 12% -10%, rgba(255, 209, 102, 0.1), transparent 65%),
-    radial-gradient(120vw 140vh at 88% 120%, rgba(96, 161, 192, 0.12), transparent 68%), var(--bg);
-  overflow-x: hidden;
-  overflow-y: auto;
+  gap: clamp(8px, 1vh, 16px);
+  overflow: hidden;
 }
 
 .app-screen > * {
-  width: 100%;
+  min-width: 0;
 }
 
 .top-bar {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: clamp(16px, 3vw, 32px);
-  padding-bottom: clamp(4px, 1vh, 12px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  gap: clamp(12px, 2vw, 24px);
+  padding-bottom: clamp(4px, 0.8vh, 10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: clamp(12px, 2vw, 20px);
+  gap: clamp(10px, 1.5vw, 18px);
 }
 
 .logo {
   display: grid;
   place-items: center;
-  width: clamp(44px, 6vw, 60px);
-  height: clamp(44px, 6vw, 60px);
-  border-radius: 50%;
-  background: rgba(255, 209, 102, 0.12);
-  font-size: clamp(22px, 4vw, 36px);
+  width: clamp(42px, 6vw, 60px);
+  height: clamp(42px, 6vw, 60px);
+  border-radius: 18px;
+  background: rgba(255, 209, 102, 0.14);
+  font-size: clamp(24px, 4vw, 36px);
 }
 
 .brand-text {
   display: flex;
   flex-direction: column;
-  gap: clamp(2px, 0.8vh, 6px);
+  gap: clamp(2px, 0.4vh, 6px);
 }
 
-.title {
+.title,
+.headline,
+.menu-title {
+  font-size: var(--font-heading);
   font-weight: 700;
-  font-size: clamp(22px, 4vw, 36px);
-  letter-spacing: 0.02em;
+  margin: 0;
+  letter-spacing: 0.01em;
 }
 
-.subtitle {
-  font-size: var(--font-sm);
+.subtitle,
+.menu-subtitle {
+  font-size: clamp(12px, 1.6vw, 18px);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.label,
+.field-label,
+.history-label,
+.menu-copy,
+.menu-link,
+.menu-secondary .btn,
+.menu-form input,
+.menu-form select,
+.menu-form option {
+  font-size: var(--font-base);
+}
+
+.label,
+.field-label,
+.history-label {
   color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.label {
-  font-size: var(--font-sm);
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+.value,
+.timer,
+.change-value,
+.panel-title,
+.denom-value,
+.ticket-price {
+  font-weight: 700;
 }
 
-.value {
-  font-weight: 700;
-  font-size: var(--font-xl);
+.timer,
+.change-value,
+.value,
+.denom-value,
+.ticket-price {
+  font-size: clamp(20px, 3.4vw, 38px);
 }
 
-.timer {
-  justify-self: end;
-  font-weight: 700;
-  font-size: clamp(26px, 5vw, 44px);
-  padding: clamp(10px, 2vh, 16px) clamp(20px, 3vw, 32px);
-  border-radius: var(--radius-md);
-  background: var(--surface-strong);
+.stat-card,
+.timer,
+.info-card,
+.tickets-panel,
+.change-panel,
+.history-panel,
+.menu-card,
+.menu-hero,
+.menu-form,
+.menu-actions,
+.menu-secondary {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
 }
 
 .stat-card {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  gap: clamp(6px, 1vh, 10px);
-  padding: clamp(12px, 2vh, 18px) clamp(16px, 3vw, 24px);
-  border-radius: var(--radius-md);
+  gap: clamp(6px, 0.8vh, 10px);
+  padding: clamp(10px, 1.6vh, 16px) clamp(14px, 2vw, 20px);
+  min-width: clamp(110px, 18vw, 160px);
+}
+
+.timer-card {
   background: var(--surface-strong);
-  box-shadow: var(--shadow-soft);
-  min-width: clamp(120px, 22vw, 180px);
-}
-
-.menu-screen {
-  justify-content: flex-start;
-  align-items: flex-start;
-}
-
-.menu-intro {
   display: flex;
   flex-direction: column;
-  gap: clamp(12px, 2vh, 18px);
-  max-width: min(70ch, 80vw);
+  justify-content: center;
+  gap: clamp(6px, 0.8vh, 10px);
 }
 
-.headline {
-  font-size: var(--font-xxl);
-  font-weight: 700;
-  margin: 0;
+.timer {
+  display: block;
+  text-align: left;
 }
 
-.lead {
-  margin: 0;
-  font-size: var(--font-lg);
-  color: var(--text-muted);
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: clamp(10px, 1.6vw, 18px);
 }
 
-.menu-form {
-  display: grid;
-  gap: clamp(12px, 2vh, 18px);
-  width: min(420px, 60vw);
-}
-
-.input-field {
-  display: grid;
-  gap: clamp(6px, 1vh, 10px);
-}
-
-input,
-select {
-  width: 100%;
-  padding: clamp(14px, 2.4vh, 20px) clamp(16px, 4vw, 24px);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: var(--surface);
-  color: var(--text-primary);
-  font-size: var(--font-lg);
-  min-height: clamp(48px, 8vh, 64px);
-}
-
-input::placeholder {
-  color: rgba(255, 255, 255, 0.45);
-}
-
-input:focus-visible,
-select:focus-visible,
-button:focus-visible {
-  outline: 2px solid rgba(255, 209, 102, 0.7);
-  outline-offset: 3px;
+.panel-title {
+  font-size: clamp(16px, 2.2vw, 24px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: clamp(8px, 1vw, 12px);
-  border-radius: var(--radius-lg);
   border: none;
+  border-radius: var(--radius-md);
+  padding: clamp(10px, 1.8vh, 16px) clamp(16px, 2.8vw, 24px);
+  font-size: var(--font-base);
   font-weight: 700;
-  font-size: var(--font-lg);
-  padding: clamp(14px, 2.6vh, 20px) clamp(22px, 5vw, 32px);
-  min-height: clamp(52px, 9vh, 70px);
+  background: var(--surface-subtle);
   color: var(--text-primary);
-  background: var(--surface-raised);
   box-shadow: var(--shadow-soft);
-  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease;
 }
 
 .btn:active {
@@ -228,145 +224,166 @@ button:focus-visible {
 
 .btn.primary {
   background: var(--accent);
-  color: #1b1f24;
-  box-shadow: 0 1.2vmin 2.6vmin rgba(255, 209, 102, 0.35);
+  color: #141921;
+  box-shadow: 0 0.8vh 2vh rgba(255, 209, 102, 0.35);
 }
 
 .btn.secondary {
-  background: var(--surface);
+  background: var(--surface-subtle);
   color: var(--text-primary);
 }
 
 .btn.ghost {
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  color: var(--text-primary);
-  min-height: clamp(48px, 8vh, 60px);
-  padding-inline: clamp(18px, 4vw, 26px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: none;
 }
 
 .btn:disabled {
-  opacity: 0.45;
-  pointer-events: none;
+  opacity: 0.4;
+  cursor: default;
+}
+
+input,
+select,
+button,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+input,
+select {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: var(--radius-md);
+  background: var(--surface-subtle);
+  padding: clamp(10px, 1.8vh, 16px) clamp(14px, 2.4vw, 22px);
+  color: var(--text-primary);
+}
+
+input::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+input:focus-visible,
+select:focus-visible,
+button:focus-visible {
+  outline: 2px solid rgba(255, 209, 102, 0.65);
+  outline-offset: 3px;
+}
+
+.menu-screen {
+  display: grid;
+  grid-template-rows: 0.16fr 0.2fr 0.26fr 0.2fr 0.18fr;
+  gap: clamp(10px, 1.4vh, 18px);
+  align-items: stretch;
+}
+
+.menu-header {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: clamp(6px, 1vh, 12px);
+}
+
+.menu-header .logo {
+  margin-bottom: clamp(2px, 0.4vh, 6px);
+}
+
+.menu-title {
+  font-size: var(--font-display);
+}
+
+.menu-subtitle {
+  letter-spacing: 0.12em;
+}
+
+.menu-hero {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: clamp(12px, 2vh, 18px);
+}
+
+.menu-hero h2 {
+  margin: 0;
+  font-size: var(--font-heading);
+  font-weight: 700;
+}
+
+.menu-hero p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-base);
+}
+
+.menu-form {
+  display: grid;
+  gap: clamp(10px, 1.4vh, 16px);
+  padding: clamp(12px, 2vh, 18px);
+}
+
+.input-field {
+  display: grid;
+  gap: clamp(6px, 0.8vh, 10px);
 }
 
 .menu-actions {
   display: flex;
+  align-items: center;
   justify-content: center;
-  width: min(420px, 60vw);
+  padding: clamp(12px, 2vh, 18px);
 }
 
 .start-btn {
-  width: 100%;
+  width: min(420px, 60vw);
+  height: 100%;
+  min-height: clamp(60px, 12vh, 80px);
 }
 
 .menu-secondary {
   display: flex;
-  gap: clamp(12px, 2vw, 20px);
-  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(10px, 1.6vw, 18px);
+  padding: clamp(12px, 2vh, 18px);
 }
 
 .menu-secondary .btn {
-  flex: 1 1 clamp(140px, 22vw, 200px);
-  min-height: clamp(48px, 8vh, 60px);
-  font-size: var(--font-base);
-}
-
-.info-panels {
-  display: grid;
-  gap: clamp(12px, 2vh, 20px);
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.info-stack {
-  display: grid;
-  gap: clamp(12px, 1.8vh, 16px);
-}
-
-.info-card {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: clamp(8px, 1.2vh, 12px);
-  padding: clamp(16px, 2.8vh, 24px) clamp(18px, 3vw, 28px);
-  border-radius: var(--radius-lg);
-  background: var(--surface-raised);
-  box-shadow: var(--shadow-soft);
-  min-height: clamp(110px, 20vh, 160px);
-}
-
-.info-card .value {
-  font-size: clamp(22px, 4vw, 42px);
-  word-break: break-word;
-}
-
-.is-muted {
-  opacity: 0.45;
-}
-
-.tickets-panel,
-.change-panel,
-.history-panel {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(12px, 2vh, 18px);
-  padding: clamp(16px, 2.6vh, 24px);
-  border-radius: var(--radius-lg);
-  background: var(--surface);
-  box-shadow: var(--shadow-soft);
-}
-
-.panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: clamp(12px, 2vw, 20px);
-}
-
-.panel-title {
-  font-weight: 700;
-  font-size: clamp(18px, 2.6vw, 26px);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  flex: 1 1 auto;
+  min-width: clamp(120px, 18vw, 160px);
+  min-height: clamp(48px, 9vh, 64px);
 }
 
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: clamp(6px, 1vh, 10px);
+  gap: clamp(4px, 0.6vh, 8px);
   overflow-y: auto;
-  padding-right: clamp(4px, 1vw, 12px);
+  padding-right: clamp(4px, 0.6vw, 10px);
 }
 
 .history-list .item {
+  background: var(--surface-subtle);
+  border-radius: var(--radius-sm);
+  padding: clamp(8px, 1.2vh, 12px) clamp(10px, 1.6vw, 14px);
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  gap: clamp(8px, 1vw, 12px);
-  padding: clamp(10px, 2vh, 14px) clamp(12px, 3vw, 18px);
-  border-radius: calc(var(--radius-md) * 0.8);
-  background: var(--surface-soft);
+  gap: clamp(6px, 1vw, 12px);
   font-size: var(--font-base);
-}
-
-.history-label {
-  color: var(--text-muted);
-  font-size: var(--font-sm);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(10, 16, 24, 0.82);
+  background: var(--overlay);
   display: grid;
   place-items: center;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.25s ease;
-  padding: clamp(24px, 6vw, 48px);
-  z-index: 20;
+  transition: opacity 0.2s ease;
+  padding: clamp(16px, 4vw, 40px);
+  z-index: 40;
 }
 
 .overlay.show {
@@ -375,29 +392,29 @@ button:focus-visible {
 }
 
 .overlay-box {
-  width: min(560px, 90vw);
+  width: min(560px, 86vw);
   max-height: min(70vh, 520px);
   overflow-y: auto;
-  background: var(--surface-raised);
+  background: var(--surface-strong);
   border-radius: var(--radius-lg);
-  padding: clamp(20px, 4vh, 32px);
+  padding: clamp(16px, 3vh, 24px);
   display: grid;
-  gap: clamp(12px, 2vh, 18px);
+  gap: clamp(10px, 1.4vh, 16px);
   box-shadow: var(--shadow-soft);
 }
 
 .overlay-box .title {
-  font-size: clamp(22px, 3.8vw, 36px);
+  font-size: var(--font-heading);
   font-weight: 700;
 }
 
 .overlay-box .small {
-  font-size: var(--font-base);
   color: var(--text-muted);
+  font-size: var(--font-base);
 }
 
 .points {
-  font-size: clamp(26px, 5vw, 44px);
+  font-size: var(--font-display);
   font-weight: 700;
 }
 
@@ -406,67 +423,57 @@ button:focus-visible {
 }
 
 .points.bad {
-  color: var(--danger);
+  color: #ff8fa3;
 }
 
 .summary-list {
   display: grid;
-  gap: clamp(8px, 1.4vh, 12px);
+  gap: clamp(8px, 1vh, 12px);
 }
 
 .s-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: clamp(8px, 2vw, 14px);
-  padding: clamp(12px, 2vh, 18px);
-  border-radius: calc(var(--radius-md) * 0.8);
+  gap: clamp(8px, 1.2vw, 14px);
+  padding: clamp(10px, 1.4vh, 14px);
+  border-radius: var(--radius-sm);
   background: var(--surface);
 }
 
 .btn-cta {
-  border-radius: var(--radius-lg);
-  border: none;
-  padding: clamp(14px, 2.4vh, 20px);
+  border-radius: var(--radius-md);
+  padding: clamp(12px, 2vh, 18px);
   background: var(--accent);
-  color: #1b1f24;
+  color: #141921;
   font-weight: 700;
-  font-size: var(--font-lg);
-  min-height: clamp(52px, 9vh, 70px);
-  box-shadow: 0 1vmin 2.2vmin rgba(255, 209, 102, 0.35);
+  font-size: var(--font-base);
+  box-shadow: 0 0.8vh 2vh rgba(255, 209, 102, 0.35);
 }
 
 .btn-cta + .btn-cta {
-  background: var(--surface);
+  background: var(--surface-subtle);
   color: var(--text-primary);
   box-shadow: var(--shadow-soft);
 }
 
-@media (max-width: 800px) {
+@media (max-width: 900px) {
   .top-bar {
     grid-template-columns: 1fr;
-    justify-items: start;
-    align-items: stretch;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .stat-card {
+    width: 100%;
+    align-items: center;
   }
 
   .timer {
-    justify-self: start;
-  }
-
-  .info-panels {
-    grid-template-columns: 1fr;
+    width: 100%;
   }
 
   .menu-screen {
-    gap: clamp(16px, 5vh, 32px);
-  }
-
-  .menu-form,
-  .menu-actions {
-    width: 100%;
-  }
-
-  .menu-secondary {
-    width: 100%;
+    grid-template-rows: repeat(5, 1fr);
   }
 }

--- a/styles/game.css
+++ b/styles/game.css
@@ -1,120 +1,165 @@
 .game-screen {
-  flex: 1 1 auto;
+  display: grid;
+  grid-template-rows: 0.14fr 0.19fr 0.23fr 0.23fr 0.21fr;
+  gap: clamp(8px, 1vh, 16px);
 }
 
 .game-screen .top-bar {
-  border-bottom: 0;
+  border-bottom: none;
+}
+
+.game-bar .stat-card {
+  justify-content: center;
+  max-width: clamp(180px, 22vw, 220px);
+  width: 100%;
+}
+
+.game-bar .stat-card .label {
+  letter-spacing: 0.12em;
+}
+
+.game-bar .stat-card .value,
+.game-bar .timer {
+  font-size: clamp(26px, 4vw, 44px);
 }
 
 .info-panels {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) repeat(2, minmax(0, 1fr));
+  gap: clamp(8px, 1vh, 14px);
   align-items: stretch;
 }
 
-.tickets-panel {
-  flex: 1 1 clamp(28vh, 36vh, 40vh);
-  overflow: hidden;
+.info-stack {
+  display: grid;
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: clamp(8px, 1vh, 12px);
+}
+
+.info-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: clamp(6px, 0.8vh, 10px);
+  padding: clamp(12px, 1.8vh, 18px) clamp(14px, 2.6vw, 20px);
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.info-card .value {
+  font-size: clamp(22px, 3.2vw, 34px);
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+.info-card .label {
+  letter-spacing: 0.1em;
+}
+
+.tickets-panel,
+.change-panel,
+.history-panel {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 1vh, 14px);
+  padding: clamp(12px, 1.8vh, 18px) clamp(14px, 2.6vw, 20px);
+}
+
+.tickets-panel .panel-header,
+.change-panel .panel-header,
+.history-panel .panel-header {
+  margin-bottom: clamp(4px, 0.6vh, 6px);
 }
 
 .ticket-grid {
-  display: flex;
-  gap: clamp(12px, 2vw, 20px);
-  overflow-x: auto;
-  padding-bottom: clamp(6px, 1vh, 10px);
-  scroll-snap-type: x proximity;
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  gap: clamp(8px, 1vh, 12px);
+  align-content: center;
 }
 
 .ticket-btn {
-  flex: 0 0 clamp(150px, 22vw, 220px);
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: clamp(8px, 1.4vh, 12px);
-  padding: clamp(16px, 2.8vh, 22px);
-  border-radius: calc(var(--radius-lg) * 0.9);
-  background: #2a3c50;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(4px, 0.6vh, 8px);
+  text-align: center;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: clamp(10px, 1.6vh, 14px);
+  width: 100%;
+  height: 100%;
   color: #101820;
-  align-items: flex-start;
-  box-shadow: var(--shadow-soft);
-  position: relative;
-  scroll-snap-align: start;
+  background: #9ad1d4;
+  box-shadow: 0 0.6vh 1.6vh rgba(0, 0, 0, 0.25);
 }
 
 .ticket-btn .ticket-icon {
-  font-size: clamp(22px, 4vw, 36px);
+  font-size: clamp(20px, 3.4vw, 32px);
 }
 
 .ticket-btn .sub {
-  font-size: var(--font-base);
   font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: clamp(12px, 1.6vw, 18px);
 }
 
 .ticket-btn .ticket-price {
-  font-size: clamp(18px, 2.8vw, 26px);
-  font-weight: 700;
+  font-size: clamp(18px, 2.6vw, 26px);
 }
 
 .ticket-btn .bubble {
   position: absolute;
-  top: clamp(10px, 2vh, 14px);
-  right: clamp(10px, 2vh, 14px);
-  padding: clamp(6px, 1vh, 10px) clamp(10px, 2vw, 14px);
+  top: clamp(6px, 0.8vh, 10px);
+  right: clamp(6px, 1vw, 10px);
+  padding: clamp(4px, 0.6vh, 8px) clamp(8px, 1.2vw, 12px);
   border-radius: 999px;
   background: rgba(16, 24, 32, 0.75);
-  color: #f4f8ff;
-  font-size: var(--font-sm);
+  color: #f4f7fb;
+  font-size: clamp(12px, 1.6vw, 16px);
   font-weight: 700;
 }
 
 .ticket-btn:disabled {
-  opacity: 0.55;
+  opacity: 0.45;
 }
 
 .ticket-btn.t-normal {
-  background: #ffb3a7;
+  background: #a5d8ff;
 }
 
 .ticket-btn.t-kid {
-  background: #9ad1d4;
+  background: #ffb5e8;
 }
 
 .ticket-btn.t-luggage {
-  background: #f6d186;
+  background: #fff3b0;
 }
 
 .ticket-btn.t-senior {
-  background: #d7bce8;
+  background: #c3f584;
 }
 
 .ticket-btn.t-disabled {
-  background: #f1c0e8;
+  background: #d0b3ff;
 }
 
 .ticket-btn.t-stroller {
-  background: #f4aeba;
+  background: #ffd6e0;
 }
 
 .ticket-btn.t-bike {
-  background: #b8e0d2;
+  background: #b8e1ff;
 }
 
 .ticket-btn.t-tourist {
-  background: #f9e79f;
-}
-
-.ticket-btn.t-normal,
-.ticket-btn.t-kid,
-.ticket-btn.t-luggage,
-.ticket-btn.t-senior,
-.ticket-btn.t-disabled,
-.ticket-btn.t-stroller,
-.ticket-btn.t-bike,
-.ticket-btn.t-tourist {
-  color: #0e1822;
-}
-
-.change-panel {
-  flex: 0 0 auto;
+  background: #e7c6ff;
 }
 
 .change-summary {
@@ -124,8 +169,7 @@
 }
 
 .change-value {
-  font-size: clamp(22px, 3.8vw, 36px);
-  font-weight: 700;
+  font-size: var(--font-display);
 }
 
 .change-value[data-state='short'] {
@@ -150,67 +194,74 @@
 }
 
 .currency-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: clamp(12px, 2vw, 18px);
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: clamp(8px, 1vh, 12px);
+  align-items: center;
+  justify-items: center;
 }
 
 .currency-btn {
-  flex: 1 1 clamp(140px, 18vw, 200px);
-  min-height: clamp(64px, 12vh, 92px);
-  border-radius: calc(var(--radius-lg) * 0.8);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: clamp(10px, 2vw, 16px);
-  padding: clamp(14px, 2.4vh, 20px) clamp(18px, 4vw, 24px);
-  background: #2a3c50;
-  color: #0e1822;
-  box-shadow: var(--shadow-soft);
+  position: relative;
+  display: grid;
+  place-items: center;
+  gap: clamp(2px, 0.4vh, 4px);
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: none;
+  background: #f6d186;
+  color: #101820;
+  box-shadow: 0 0.6vh 1.6vh rgba(0, 0, 0, 0.35);
+  text-align: center;
+  padding: clamp(6px, 0.8vh, 10px);
 }
 
 .currency-btn .denom-icon {
-  font-size: clamp(20px, 3.4vw, 32px);
+  font-size: clamp(16px, 2.4vw, 20px);
+  opacity: 0.65;
 }
 
 .currency-btn .denom-value {
   font-size: clamp(18px, 2.8vw, 26px);
-  font-weight: 700;
 }
 
 .currency-btn .denom-label {
-  font-size: var(--font-sm);
-  text-transform: uppercase;
+  font-size: clamp(12px, 1.6vw, 16px);
   letter-spacing: 0.08em;
-  color: rgba(14, 24, 34, 0.7);
+  text-transform: uppercase;
+  color: rgba(16, 24, 32, 0.6);
 }
 
-.currency-btn.bill {
-  background: #b8e0d2;
+.currency-btn.skin-blue {
+  background: #4da3ff;
+  color: #0b1c2c;
 }
 
-.currency-btn.coin {
-  background: #f6d186;
-}
-
-.currency-btn.skin-emerald {
-  background: #8bd3c7;
-}
-
-.currency-btn.skin-emerald-light {
-  background: #c9f2e7;
-}
-
-.currency-btn.skin-teal {
-  background: #9ad1d4;
+.currency-btn.skin-gold {
+  background: #ffd166;
+  color: #1b1f24;
 }
 
 .currency-btn.skin-silver {
-  background: #d8e6f3;
+  background: #dce6f5;
+  color: #1b1f24;
 }
 
-.currency-btn.skin-copper {
-  background: #f2c3a7;
+.currency-btn.skin-bronze {
+  background: #f0b27a;
+  color: #1b1f24;
+}
+
+.currency-btn.skin-bronze-dark {
+  background: #d99863;
+  color: #1b1f24;
+}
+
+.currency-btn.skin-bronze-soft {
+  background: #f7c89c;
+  color: #1b1f24;
 }
 
 .currency-btn:hover {
@@ -218,13 +269,26 @@
 }
 
 .history-panel {
-  flex: 0 0 clamp(120px, 25vh, 220px);
+  overflow: hidden;
 }
 
 .history-list {
-  max-height: 100%;
+  flex: 1;
 }
 
-.overlay-box {
-  max-width: min(600px, 92vw);
+@media (max-width: 900px) {
+  .info-panels {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(4, minmax(0, 1fr));
+  }
+
+  .info-stack {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: none;
+  }
+
+  .ticket-grid,
+  .currency-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }


### PR DESCRIPTION
## Summary
- enforce a 100vh landscape grid layout with responsive typography and shared dark palette for all screens
- restyle ticket cards and currency controls with flat pastel colors and limit change options to six denominations
- align the menu with the in-game presentation, centering the hero block and enlarging the start CTA

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d71c4be2bc8329be391640f2282164