### PR TITLE
Implement responsive landscape grid for Ticket Rush PRO

### DIFF
--- a/game.html
+++ b/game.html
@@ -13,7 +13,7 @@
 </head>
 <body class="app-body">
   <main class="app-screen game-screen" role="main">
-    <header class="top-bar game-bar">
+    <header class="top-bar game-top">
       <div class="brand">
         <span class="logo" aria-hidden="true">🚌</span>
         <div class="brand-text">
@@ -31,52 +31,65 @@
       </div>
     </header>
 
-    <section class="info-panels" aria-live="polite">
-      <div class="info-stack">
-        <article class="info-card">
-          <span class="label">Passenger needs</span>
-          <span class="value" id="need">—</span>
-        </article>
-        <article class="info-card" id="paysCard">
-          <span class="label">Pays</span>
-          <span class="value" id="pays">—</span>
-        </article>
-      </div>
-      <article class="info-card">
-        <span class="label">Tickets value</span>
-        <span class="value" id="fare">$0.00</span>
-      </article>
-      <article class="info-card">
-        <span class="label">Selected value</span>
-        <span class="value" id="picked">$0.00</span>
-      </article>
-    </section>
+    <section class="game-content" aria-label="Passenger needs and payment tools">
+      <div class="game-column column-left">
+        <section class="panel needs-panel" aria-label="Passenger needs">
+          <div class="panel-header">
+            <span class="panel-title">Passenger Needs</span>
+          </div>
+          <div class="needs-grid">
+            <article class="info-card">
+              <span class="label">Needs</span>
+              <span class="value" id="need">—</span>
+            </article>
+            <article class="info-card" id="paysCard">
+              <span class="label">Pays</span>
+              <span class="value" id="pays">—</span>
+            </article>
+            <article class="info-card">
+              <span class="label">Tickets value</span>
+              <span class="value" id="fare">$0.00</span>
+            </article>
+            <article class="info-card">
+              <span class="label">Selected value</span>
+              <span class="value" id="picked">$0.00</span>
+            </article>
+          </div>
+        </section>
 
-    <section class="tickets-panel" aria-label="Tickets">
-      <div class="panel-header">
-        <span class="panel-title">Tickets</span>
-        <button class="btn ghost" id="clearTickets" type="button">Clear</button>
+        <section class="panel tickets-panel" aria-label="Tickets">
+          <div class="panel-header">
+            <span class="panel-title">Tickets</span>
+          </div>
+          <div class="tickets-track" id="tickets"></div>
+        </section>
       </div>
-      <div class="ticket-grid" id="tickets"></div>
-    </section>
 
-    <section class="change-panel" aria-label="Change" data-visible="false">
-      <div class="panel-header">
-        <span class="panel-title">Change</span>
-        <div class="change-summary">
-          <span class="label" id="changeLabel">Change</span>
-          <span class="change-value" id="remain">$?</span>
+      <section class="panel change-panel pay" aria-label="Change" data-visible="false">
+        <div class="panel-header">
+          <span class="panel-title">Change</span>
+          <div class="change-summary">
+            <span class="label" id="changeLabel">Change</span>
+            <span class="change-value" id="remain">$?</span>
+          </div>
         </div>
-      </div>
-      <div class="currency-grid" id="coins"></div>
+        <div class="currency-grid" id="coins"></div>
+      </section>
     </section>
 
-    <section class="history-panel" aria-label="History">
-      <div class="panel-header">
-        <span class="panel-title">History</span>
+    <footer class="bottom-bar game-bottom" aria-label="Round history and actions">
+      <section class="panel history-panel" aria-label="History">
+        <div class="panel-header">
+          <span class="panel-title">History</span>
+        </div>
+        <div class="history-list" id="history"></div>
+      </section>
+      <div class="panel action-panel" role="group" aria-label="Game controls">
+        <button class="btn ghost" id="clearTickets" type="button">Clear</button>
+        <button class="btn secondary" id="restartGame" type="button">Restart</button>
+        <button class="btn secondary" id="menuButton" type="button">Menu</button>
       </div>
-      <div class="history-list" id="history"></div>
-    </section>
+    </footer>
   </main>
 
   <div class="overlay" id="overlay" role="alertdialog" aria-modal="true" aria-hidden="true">

--- a/js/screens/game.js
+++ b/js/screens/game.js
@@ -32,6 +32,8 @@ const overlayElements = {
 };
 
 const clearButton = document.getElementById('clearTickets');
+const restartButton = document.getElementById('restartGame');
+const menuButton = document.getElementById('menuButton');
 
 let roundActive = false;
 let finishing = false;
@@ -158,6 +160,20 @@ if (clearButton) {
     if (!roundActive) return;
     clearTickets(SESSION);
     syncUI();
+  });
+}
+
+if (restartButton) {
+  restartButton.addEventListener('click', () => {
+    stopRound();
+    window.location.reload();
+  });
+}
+
+if (menuButton) {
+  menuButton.addEventListener('click', () => {
+    stopRound();
+    navigateToMenu();
   });
 }
 

--- a/menu.html
+++ b/menu.html
@@ -12,46 +12,52 @@
 </head>
 <body class="app-body">
   <main class="app-screen menu-screen" role="main">
-    <header class="menu-header">
-      <span class="logo" aria-hidden="true">🚌</span>
-      <h1 class="menu-title">Ticket Rush PRO</h1>
-      <p class="menu-subtitle">Ticket counter training</p>
+    <header class="top-bar menu-top">
+      <div class="brand">
+        <span class="logo" aria-hidden="true">🚌</span>
+        <div class="brand-text">
+          <span class="title">Ticket Rush PRO</span>
+          <span class="subtitle">Ticket counter training</span>
+        </div>
+      </div>
+      <div class="menu-tagline">
+        <p>Sharpen your reflexes and deliver perfect change in seconds.</p>
+      </div>
     </header>
 
-    <section class="menu-hero">
-      <div>
-        <h2>Ready for the rush?</h2>
-        <p class="menu-copy">Enter your details, pick a mode, and jump straight into the booth.</p>
+    <section class="menu-content">
+      <div class="menu-center">
+        <form class="menu-form" aria-label="Start a new game" onsubmit="return false;">
+          <label class="input-field" for="playerName">
+            <span class="field-label">Nickname</span>
+            <input
+              type="text"
+              id="playerName"
+              name="playerName"
+              placeholder="Enter your name"
+              autocomplete="off"
+              inputmode="text"
+            />
+          </label>
+
+          <label class="input-field" for="modeSelect">
+            <span class="field-label">Game mode</span>
+            <select id="modeSelect" name="mode"></select>
+          </label>
+        </form>
+        <div class="menu-actions">
+          <button class="btn primary start-btn" id="startBtn" type="button">Start game</button>
+          <div class="menu-secondary" role="group" aria-label="Additional options">
+            <button class="btn secondary" type="button">Modes</button>
+            <button class="btn secondary" type="button">Settings</button>
+          </div>
+        </div>
       </div>
     </section>
 
-    <form class="menu-form" aria-label="Start a new game" onsubmit="return false;">
-      <label class="input-field" for="playerName">
-        <span class="field-label">Nickname</span>
-        <input
-          type="text"
-          id="playerName"
-          name="playerName"
-          placeholder="Enter your name"
-          autocomplete="off"
-          inputmode="text"
-        />
-      </label>
-
-      <label class="input-field" for="modeSelect">
-        <span class="field-label">Game mode</span>
-        <select id="modeSelect" name="mode"></select>
-      </label>
-    </form>
-
-    <div class="menu-actions">
-      <button class="btn primary start-btn" id="startBtn" type="button">Start game</button>
-    </div>
-
-    <div class="menu-secondary" role="group" aria-label="Additional options">
-      <button class="btn secondary" type="button">Modes</button>
-      <button class="btn secondary" type="button">Settings</button>
-    </div>
+    <footer class="menu-bottom">
+      <p class="menu-footer">Built for landscape play — keep your device steady and get ready for the rush.</p>
+    </footer>
   </main>
 </body>
 </html>

--- a/styles/app.css
+++ b/styles/app.css
@@ -8,14 +8,14 @@
   --text-primary: #f4f7fb;
   --text-muted: #92a4b8;
   --accent: #ffd166;
-  --shadow-soft: 0 0.8vh 2.2vh rgba(0, 0, 0, 0.38);
+  --shadow-soft: 0 0.8vh 2vh rgba(0, 0, 0, 0.35);
   --radius-sm: clamp(10px, 0.8vw, 14px);
   --radius-md: clamp(14px, 1.2vw, 18px);
   --radius-lg: clamp(18px, 1.8vw, 26px);
-  --font-base: clamp(14px, 2vw, 22px);
-  --font-heading: clamp(20px, 3.2vw, 34px);
-  --font-display: clamp(28px, 4vw, 46px);
-  --font-huge: clamp(36px, 5.2vw, 60px);
+  --font-base: clamp(14px, 2vw, 20px);
+  --font-heading: clamp(20px, 3vw, 30px);
+  --font-display: clamp(28px, 4vw, 40px);
+  --font-huge: clamp(36px, 5vw, 56px);
 }
 
 *,
@@ -52,16 +52,17 @@ body,
   display: flex;
   align-items: stretch;
   justify-content: center;
+  background: var(--bg);
 }
 
 .app-screen {
   width: 100vw;
   height: 100vh;
-  padding: clamp(12px, 3vh, 24px) clamp(16px, 4vw, 32px);
+  padding: clamp(12px, 2vh, 24px) clamp(16px, 3vw, 32px);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: clamp(12px, 1.6vh, 20px);
   background: var(--bg);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(8px, 1vh, 16px);
   overflow: hidden;
 }
 
@@ -71,27 +72,27 @@ body,
 
 .top-bar {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: minmax(0, 0.5fr) minmax(0, 0.25fr) minmax(0, 0.25fr);
   align-items: center;
   gap: clamp(12px, 2vw, 24px);
-  padding-bottom: clamp(4px, 0.8vh, 10px);
+  padding-bottom: clamp(6px, 0.8vh, 10px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: clamp(10px, 1.5vw, 18px);
+  gap: clamp(10px, 1.8vw, 22px);
 }
 
 .logo {
   display: grid;
   place-items: center;
-  width: clamp(42px, 6vw, 60px);
-  height: clamp(42px, 6vw, 60px);
+  width: clamp(46px, 6vw, 64px);
+  height: clamp(46px, 6vw, 64px);
   border-radius: 18px;
   background: rgba(255, 209, 102, 0.14);
-  font-size: clamp(24px, 4vw, 36px);
+  font-size: clamp(26px, 4vw, 38px);
 }
 
 .brand-text {
@@ -101,7 +102,6 @@ body,
 }
 
 .title,
-.headline,
 .menu-title {
   font-size: var(--font-heading);
   font-weight: 700;
@@ -122,7 +122,7 @@ body,
 .field-label,
 .history-label,
 .menu-copy,
-.menu-link,
+.menu-footer,
 .menu-secondary .btn,
 .menu-form input,
 .menu-form select,
@@ -152,44 +152,41 @@ body,
 .value,
 .denom-value,
 .ticket-price {
-  font-size: clamp(20px, 3.4vw, 38px);
+  font-size: clamp(20px, 3.2vw, 34px);
 }
 
+.panel,
 .stat-card,
-.timer,
+.timer-card,
 .info-card,
-.tickets-panel,
-.change-panel,
-.history-panel,
-.menu-card,
-.menu-hero,
 .menu-form,
 .menu-actions,
-.menu-secondary {
+.menu-secondary,
+.menu-bottom,
+.action-panel {
   background: var(--surface);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
+  padding: clamp(12px, 1.8vh, 18px) clamp(16px, 2.6vw, 24px);
 }
 
-.stat-card {
+.info-card {
   display: flex;
   flex-direction: column;
   gap: clamp(6px, 0.8vh, 10px);
-  padding: clamp(10px, 1.6vh, 16px) clamp(14px, 2vw, 20px);
-  min-width: clamp(110px, 18vw, 160px);
+  justify-content: center;
 }
 
+.stat-card,
 .timer-card {
-  background: var(--surface-strong);
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: clamp(6px, 0.8vh, 10px);
 }
 
-.timer {
-  display: block;
-  text-align: left;
+.timer-card {
+  background: var(--surface-strong);
 }
 
 .panel-header {
@@ -197,10 +194,11 @@ body,
   justify-content: space-between;
   align-items: center;
   gap: clamp(10px, 1.6vw, 18px);
+  margin-bottom: clamp(6px, 0.8vh, 10px);
 }
 
 .panel-title {
-  font-size: clamp(16px, 2.2vw, 24px);
+  font-size: clamp(16px, 2.4vw, 24px);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -273,92 +271,10 @@ button:focus-visible {
   outline-offset: 3px;
 }
 
-.menu-screen {
-  display: grid;
-  grid-template-rows: 0.16fr 0.2fr 0.26fr 0.2fr 0.18fr;
-  gap: clamp(10px, 1.4vh, 18px);
-  align-items: stretch;
-}
-
-.menu-header {
-  display: grid;
-  place-items: center;
-  text-align: center;
-  gap: clamp(6px, 1vh, 12px);
-}
-
-.menu-header .logo {
-  margin-bottom: clamp(2px, 0.4vh, 6px);
-}
-
-.menu-title {
-  font-size: var(--font-display);
-}
-
-.menu-subtitle {
-  letter-spacing: 0.12em;
-}
-
-.menu-hero {
-  display: grid;
-  place-items: center;
-  text-align: center;
-  padding: clamp(12px, 2vh, 18px);
-}
-
-.menu-hero h2 {
-  margin: 0;
-  font-size: var(--font-heading);
-  font-weight: 700;
-}
-
-.menu-hero p {
-  margin: 0;
-  color: var(--text-muted);
-  font-size: var(--font-base);
-}
-
-.menu-form {
-  display: grid;
-  gap: clamp(10px, 1.4vh, 16px);
-  padding: clamp(12px, 2vh, 18px);
-}
-
-.input-field {
-  display: grid;
-  gap: clamp(6px, 0.8vh, 10px);
-}
-
-.menu-actions {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(12px, 2vh, 18px);
-}
-
-.start-btn {
-  width: min(420px, 60vw);
-  height: 100%;
-  min-height: clamp(60px, 12vh, 80px);
-}
-
-.menu-secondary {
-  display: flex;
-  justify-content: center;
-  gap: clamp(10px, 1.6vw, 18px);
-  padding: clamp(12px, 2vh, 18px);
-}
-
-.menu-secondary .btn {
-  flex: 1 1 auto;
-  min-width: clamp(120px, 18vw, 160px);
-  min-height: clamp(48px, 9vh, 64px);
-}
-
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: clamp(4px, 0.6vh, 8px);
+  gap: clamp(6px, 0.8vh, 10px);
   overflow-y: auto;
   padding-right: clamp(4px, 0.6vw, 10px);
 }
@@ -371,6 +287,86 @@ button:focus-visible {
   justify-content: space-between;
   gap: clamp(6px, 1vw, 12px);
   font-size: var(--font-base);
+}
+
+.menu-screen {
+  grid-template-rows: 0.16fr 0.64fr 0.2fr;
+}
+
+.menu-top {
+  grid-template-columns: minmax(0, 0.5fr) minmax(0, 0.5fr);
+}
+
+.menu-top .brand {
+  justify-self: start;
+}
+
+.menu-tagline {
+  align-self: center;
+  justify-self: end;
+  max-width: clamp(220px, 32vw, 340px);
+  font-size: var(--font-base);
+  color: var(--text-muted);
+}
+
+.menu-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+}
+
+.menu-center {
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: clamp(14px, 2vh, 24px);
+  width: min(720px, 86vw);
+}
+
+.menu-form {
+  display: grid;
+  gap: clamp(10px, 1.6vh, 18px);
+}
+
+.input-field {
+  display: grid;
+  gap: clamp(6px, 0.8vh, 10px);
+}
+
+.menu-actions {
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: clamp(12px, 1.8vh, 18px);
+  text-align: center;
+}
+
+.start-btn {
+  width: 100%;
+  min-height: clamp(64px, 16vh, 96px);
+  font-size: var(--font-display);
+}
+
+.menu-secondary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(10px, 1.6vw, 18px);
+  padding: clamp(10px, 1.4vh, 16px);
+}
+
+.menu-secondary .btn {
+  min-height: clamp(48px, 12vh, 64px);
+}
+
+.menu-bottom {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding-block: clamp(12px, 1.8vh, 18px);
+}
+
+.menu-footer {
+  margin: 0;
+  color: var(--text-muted);
 }
 
 .overlay {
@@ -400,7 +396,6 @@ button:focus-visible {
   padding: clamp(16px, 3vh, 24px);
   display: grid;
   gap: clamp(10px, 1.4vh, 16px);
-  box-shadow: var(--shadow-soft);
 }
 
 .overlay-box .title {
@@ -413,67 +408,44 @@ button:focus-visible {
   font-size: var(--font-base);
 }
 
-.points {
+.overlay-box .points {
   font-size: var(--font-display);
   font-weight: 700;
 }
 
-.points.good {
+.overlay-box .points.good {
   color: #6ce5b1;
 }
 
-.points.bad {
+.overlay-box .points.bad {
   color: #ff8fa3;
 }
 
-.summary-list {
+.overlay-box .summary-list {
   display: grid;
-  gap: clamp(8px, 1vh, 12px);
+  gap: clamp(6px, 0.8vh, 10px);
 }
 
-.s-item {
+.overlay-box .s-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: clamp(8px, 1.2vw, 14px);
-  padding: clamp(10px, 1.4vh, 14px);
-  border-radius: var(--radius-sm);
-  background: var(--surface);
-}
-
-.btn-cta {
-  border-radius: var(--radius-md);
-  padding: clamp(12px, 2vh, 18px);
-  background: var(--accent);
-  color: #141921;
-  font-weight: 700;
-  font-size: var(--font-base);
-  box-shadow: 0 0.8vh 2vh rgba(255, 209, 102, 0.35);
-}
-
-.btn-cta + .btn-cta {
-  background: var(--surface-subtle);
-  color: var(--text-primary);
-  box-shadow: var(--shadow-soft);
+  gap: clamp(6px, 1vw, 12px);
 }
 
 @media (max-width: 900px) {
   .top-bar {
+    grid-template-columns: minmax(0, 0.6fr) minmax(0, 0.2fr) minmax(0, 0.2fr);
+  }
+
+  .menu-top {
     grid-template-columns: 1fr;
-    justify-items: center;
-    text-align: center;
+    justify-items: start;
+    row-gap: clamp(10px, 1.6vh, 18px);
   }
 
-  .stat-card {
-    width: 100%;
-    align-items: center;
-  }
-
-  .timer {
-    width: 100%;
-  }
-
-  .menu-screen {
-    grid-template-rows: repeat(5, 1fr);
+  .menu-tagline {
+    max-width: none;
+    justify-self: start;
   }
 }

--- a/styles/game.css
+++ b/styles/game.css
@@ -1,102 +1,104 @@
 .game-screen {
-  display: grid;
-  grid-template-rows: 0.14fr 0.19fr 0.23fr 0.23fr 0.21fr;
-  gap: clamp(8px, 1vh, 16px);
+  grid-template-rows: 0.14fr 0.62fr 0.24fr;
 }
 
-.game-screen .top-bar {
+.game-top {
   border-bottom: none;
+  grid-template-columns: minmax(0, 0.4fr) minmax(0, 0.2fr) minmax(0, 0.4fr);
 }
 
-.game-bar .stat-card {
-  justify-content: center;
-  max-width: clamp(180px, 22vw, 220px);
-  width: 100%;
+.game-top .stat-card,
+.game-top .timer-card {
+  align-self: stretch;
+  text-align: left;
 }
 
-.game-bar .stat-card .label {
-  letter-spacing: 0.12em;
-}
-
-.game-bar .stat-card .value,
-.game-bar .timer {
+.game-top .stat-card .value,
+.game-top .timer {
   font-size: clamp(26px, 4vw, 44px);
 }
 
-.info-panels {
+.game-content {
   display: grid;
-  grid-template-columns: minmax(0, 1.4fr) repeat(2, minmax(0, 1fr));
-  gap: clamp(8px, 1vh, 14px);
-  align-items: stretch;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(12px, 2vw, 24px);
+  min-height: 0;
 }
 
-.info-stack {
+.game-column {
   display: grid;
-  grid-template-rows: repeat(2, minmax(0, 1fr));
-  gap: clamp(8px, 1vh, 12px);
+  grid-template-rows: minmax(0, 0.45fr) minmax(0, 0.55fr);
+  gap: clamp(12px, 1.6vh, 18px);
+  min-height: 0;
 }
 
-.info-card {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: clamp(6px, 0.8vh, 10px);
-  padding: clamp(12px, 1.8vh, 18px) clamp(14px, 2.6vw, 20px);
-  background: var(--surface);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-soft);
-}
-
-.info-card .value {
-  font-size: clamp(22px, 3.2vw, 34px);
-  line-height: 1.1;
-  color: var(--text-primary);
-}
-
-.info-card .label {
-  letter-spacing: 0.1em;
-}
-
+.needs-panel,
 .tickets-panel,
 .change-panel,
-.history-panel {
+.history-panel,
+.action-panel {
   display: flex;
   flex-direction: column;
-  gap: clamp(8px, 1vh, 14px);
-  padding: clamp(12px, 1.8vh, 18px) clamp(14px, 2.6vw, 20px);
+  gap: clamp(10px, 1.4vh, 16px);
+  min-height: 0;
 }
 
-.tickets-panel .panel-header,
-.change-panel .panel-header,
-.history-panel .panel-header {
-  margin-bottom: clamp(4px, 0.6vh, 6px);
-}
-
-.ticket-grid {
-  flex: 1;
+.needs-grid {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  grid-auto-rows: 1fr;
-  gap: clamp(8px, 1vh, 12px);
-  align-content: center;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(10px, 1.4vh, 16px);
+  min-height: 0;
+}
+
+.needs-grid .info-card {
+  min-height: 0;
+}
+
+.info-card.is-muted {
+  opacity: 0.45;
+}
+
+.tickets-panel {
+  justify-content: space-between;
+}
+
+.tickets-track {
+  flex: 1;
+  display: flex;
+  gap: clamp(12px, 2vw, 18px);
+  align-items: stretch;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: clamp(6px, 0.8vh, 10px);
+  scroll-snap-type: x proximity;
+}
+
+.tickets-track::-webkit-scrollbar {
+  height: clamp(6px, 0.8vh, 8px);
+}
+
+.tickets-track::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
 }
 
 .ticket-btn {
   position: relative;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 0.6vh, 8px);
+  gap: clamp(6px, 1vh, 10px);
   text-align: center;
   border: none;
   border-radius: var(--radius-md);
-  padding: clamp(10px, 1.6vh, 14px);
-  width: 100%;
-  height: 100%;
+  padding: clamp(10px, 1.6vh, 16px);
+  width: clamp(120px, 18vw, 180px);
+  height: min(18vh, 26vw);
   color: #101820;
-  background: #9ad1d4;
   box-shadow: 0 0.6vh 1.6vh rgba(0, 0, 0, 0.25);
+  scroll-snap-align: center;
 }
 
 .ticket-btn .ticket-icon {
@@ -135,7 +137,7 @@
 }
 
 .ticket-btn.t-kid {
-  background: #ffb5e8;
+  background: #c3f584;
 }
 
 .ticket-btn.t-luggage {
@@ -143,7 +145,7 @@
 }
 
 .ticket-btn.t-senior {
-  background: #c3f584;
+  background: #ffd6e0;
 }
 
 .ticket-btn.t-disabled {
@@ -151,15 +153,15 @@
 }
 
 .ticket-btn.t-stroller {
-  background: #ffd6e0;
-}
-
-.ticket-btn.t-bike {
   background: #b8e1ff;
 }
 
-.ticket-btn.t-tourist {
+.ticket-btn.t-bike {
   background: #e7c6ff;
+}
+
+.ticket-btn.t-tourist {
+  background: #ffb5e8;
 }
 
 .change-summary {
@@ -186,7 +188,7 @@
 
 .change-panel[data-visible='false'] .currency-grid,
 .change-panel[data-visible='false'] .change-summary {
-  opacity: 0.4;
+  opacity: 0.45;
 }
 
 .change-panel[data-visible='false'] .currency-grid {
@@ -195,11 +197,12 @@
 
 .currency-grid {
   flex: 1;
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: clamp(8px, 1vh, 12px);
-  align-items: center;
-  justify-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-content: space-evenly;
+  gap: clamp(12px, 2vw, 18px);
+  padding-block: clamp(6px, 0.8vh, 12px);
 }
 
 .currency-btn {
@@ -207,8 +210,8 @@
   display: grid;
   place-items: center;
   gap: clamp(2px, 0.4vh, 4px);
-  width: 100%;
-  aspect-ratio: 1 / 1;
+  width: min(10vh, 10vw);
+  height: min(10vh, 10vw);
   border-radius: 50%;
   border: none;
   background: #f6d186;
@@ -224,7 +227,7 @@
 }
 
 .currency-btn .denom-value {
-  font-size: clamp(18px, 2.8vw, 26px);
+  font-size: clamp(16px, 2.6vw, 24px);
 }
 
 .currency-btn .denom-label {
@@ -235,7 +238,7 @@
 }
 
 .currency-btn.skin-blue {
-  background: #4da3ff;
+  background: #70c2ff;
   color: #0b1c2c;
 }
 
@@ -264,8 +267,11 @@
   color: #1b1f24;
 }
 
-.currency-btn:hover {
-  filter: brightness(1.05);
+.bottom-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 0.7fr) minmax(0, 0.3fr);
+  gap: clamp(12px, 2vw, 24px);
+  min-height: 0;
 }
 
 .history-panel {
@@ -276,19 +282,41 @@
   flex: 1;
 }
 
-@media (max-width: 900px) {
-  .info-panels {
+.action-panel {
+  justify-content: space-between;
+  align-items: stretch;
+}
+
+.action-panel .btn {
+  width: 100%;
+}
+
+@media (max-width: 1100px) {
+  .needs-grid {
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(4, minmax(0, 1fr));
   }
 
-  .info-stack {
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: none;
+  .ticket-btn {
+    width: clamp(120px, 26vw, 200px);
+  }
+}
+
+@media (max-width: 900px) {
+  .game-screen {
+    grid-template-rows: 0.16fr 0.6fr 0.24fr;
   }
 
-  .ticket-grid,
-  .currency-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .game-content {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+  }
+
+  .game-column {
+    grid-template-rows: minmax(0, 0.5fr) minmax(0, 0.5fr);
+  }
+
+  .bottom-bar {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 0.7fr) minmax(0, 0.3fr);
   }
 }


### PR DESCRIPTION
## Summary
- restructure the game screen into a three-zone landscape grid with aligned HUD, ticket rail, coin tray, and history controls
- update shared styles to enforce responsive typography and proportional sizing for tickets and coins across 100vw × 100vh layouts
- refresh the menu screen to follow the same landscape grid pattern and add restart/menu hooks for gameplay controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d79e1162cc8329b3439656cf388a39