### PR TITLE
feat(landscape): proportional grid, clamp fonts, 8 tickets + 3 bills + 5 coins visible

### DIFF
--- a/game.html
+++ b/game.html
@@ -31,53 +31,49 @@
       </div>
     </header>
 
-    <section class="game-content" aria-label="Passenger needs and payment tools">
-      <div class="game-column column-left">
-        <section class="panel needs-panel" aria-label="Passenger needs">
-          <div class="panel-header">
-            <span class="panel-title">Passenger Needs</span>
-          </div>
-          <div class="needs-grid">
-            <article class="info-card">
-              <span class="label">Needs</span>
-              <span class="value" id="need">—</span>
-            </article>
-            <article class="info-card" id="paysCard">
-              <span class="label">Pays</span>
-              <span class="value" id="pays">—</span>
-            </article>
-            <article class="info-card">
-              <span class="label">Tickets value</span>
-              <span class="value" id="fare">$0.00</span>
-            </article>
-            <article class="info-card">
-              <span class="label">Selected value</span>
-              <span class="value" id="picked">$0.00</span>
-            </article>
-          </div>
-        </section>
-
-        <section class="panel tickets-panel" aria-label="Tickets">
-          <div class="panel-header">
-            <span class="panel-title">Tickets</span>
-          </div>
-          <div class="tickets-track" id="tickets"></div>
-        </section>
+    <section class="panel needs-panel hud-panel" aria-label="Passenger needs">
+      <div class="panel-header">
+        <span class="panel-title">Passenger Needs</span>
       </div>
-
-      <section class="panel change-panel pay" aria-label="Change" data-visible="false">
-        <div class="panel-header">
-          <span class="panel-title">Change</span>
-          <div class="change-summary">
-            <span class="label" id="changeLabel">Change</span>
-            <span class="change-value" id="remain">$?</span>
-          </div>
-        </div>
-        <div class="currency-grid" id="coins"></div>
-      </section>
+      <div class="needs-grid">
+        <article class="info-card">
+          <span class="label">Needs</span>
+          <span class="value" id="need">—</span>
+        </article>
+        <article class="info-card" id="paysCard">
+          <span class="label">Pays</span>
+          <span class="value" id="pays">—</span>
+        </article>
+        <article class="info-card">
+          <span class="label">Tickets value</span>
+          <span class="value" id="fare">$0.00</span>
+        </article>
+        <article class="info-card">
+          <span class="label">Selected value</span>
+          <span class="value" id="picked">$0.00</span>
+        </article>
+      </div>
     </section>
 
-    <footer class="bottom-bar game-bottom" aria-label="Round history and actions">
+    <section class="panel tickets-panel" aria-label="Tickets">
+      <div class="panel-header">
+        <span class="panel-title">Tickets</span>
+      </div>
+      <div class="grid-tickets" id="tickets"></div>
+    </section>
+
+    <section class="panel change-panel pay" aria-label="Change" data-visible="false">
+      <div class="panel-header">
+        <span class="panel-title">Change</span>
+        <div class="change-summary">
+          <span class="label" id="changeLabel">Change</span>
+          <span class="change-value" id="remain">$?</span>
+        </div>
+      </div>
+      <div class="currency-grid grid-coins" id="coins"></div>
+    </section>
+
+    <section class="history-row" aria-label="Round history and actions">
       <section class="panel history-panel" aria-label="History">
         <div class="panel-header">
           <span class="panel-title">History</span>
@@ -89,7 +85,7 @@
         <button class="btn secondary" id="restartGame" type="button">Restart</button>
         <button class="btn secondary" id="menuButton" type="button">Menu</button>
       </div>
-    </footer>
+    </section>
   </main>
 
   <div class="overlay" id="overlay" role="alertdialog" aria-modal="true" aria-hidden="true">

--- a/js/game/constants.js
+++ b/js/game/constants.js
@@ -9,14 +9,21 @@ export const ALL_TICKETS = [
   { name: 'Tourist', price: 1.5, className: 't-tourist', icon: '🧭' },
 ];
 
-export const DENOMINATIONS = [
-  { value: 2, type: 'coin', skin: 'blue', label: 'Express coin', icon: '②', toggleKey: 'allowTwo' },
-  { value: 1, type: 'coin', skin: 'gold', label: 'Dollar coin', icon: '①' },
-  { value: 0.5, type: 'coin', skin: 'silver', label: 'Half coin', icon: '◎' },
+export const BILLS = [
+  { value: 5, type: 'bill', skin: 'bill', label: '$5 bill', icon: '⑤' },
+  { value: 2, type: 'bill', skin: 'bill-alt', label: '$2 bill', icon: '②', toggleKey: 'allowTwo' },
+  { value: 1, type: 'bill', skin: 'bill-soft', label: '$1 bill', icon: '①' },
+];
+
+export const COINS = [
+  { value: 0.5, type: 'coin', skin: 'gold', label: 'Half dollar', icon: '◎' },
+  { value: 0.2, type: 'coin', skin: 'silver', label: 'Twenty cents', icon: '◑' },
   { value: 0.1, type: 'coin', skin: 'bronze', label: 'Dime', icon: '◉' },
   { value: 0.05, type: 'coin', skin: 'bronze-dark', label: 'Nickel', icon: '◍' },
   { value: 0.01, type: 'coin', skin: 'bronze-soft', label: 'Penny', icon: '∙', toggleKey: 'allowOneCent' },
 ];
+
+export const DENOMINATIONS = [...BILLS, ...COINS];
 
 export const COIN_TOGGLES = {
   allowTwo: true,

--- a/js/game/render.js
+++ b/js/game/render.js
@@ -54,10 +54,13 @@ export function renderTickets(session, elements, handlers) {
 
 export function renderCoins(session, elements, handlers) {
   const { coinsWrap } = elements;
-  const fragment = document.createDocumentFragment();
-
   const denominations =
     typeof handlers.getAvailableCoins === 'function' ? handlers.getAvailableCoins() : handlers.availableCoins;
+
+  const billsRow = document.createElement('div');
+  billsRow.className = 'coins-row bills';
+  const coinsRow = document.createElement('div');
+  coinsRow.className = 'coins-row coins';
 
   denominations.forEach((denomination) => {
     const button = document.createElement('button');
@@ -74,9 +77,17 @@ export function renderCoins(session, elements, handlers) {
       <span class="denom-label">${denomination.label}</span>
     `;
     button.addEventListener('click', () => handlers.onInsertCoin(denomination.value));
-    fragment.appendChild(button);
+    if (denomination.type === 'bill') {
+      billsRow.appendChild(button);
+    } else {
+      coinsRow.appendChild(button);
+    }
   });
 
+  const fragment = document.createDocumentFragment();
+  fragment.append(billsRow, coinsRow);
+
+  coinsWrap.classList.add('grid-coins');
   coinsWrap.replaceChildren(fragment);
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -9,13 +9,13 @@
   --text-muted: #92a4b8;
   --accent: #ffd166;
   --shadow-soft: 0 0.8vh 2vh rgba(0, 0, 0, 0.35);
-  --radius-sm: clamp(8px, 0.7vw, 12px);
-  --radius-md: clamp(12px, 1vw, 16px);
-  --radius-lg: clamp(16px, 1.4vw, 22px);
-  --font-base: clamp(14px, 2vw, 20px);
-  --font-heading: clamp(18px, 2.4vw, 26px);
-  --font-display: clamp(24px, 3.2vw, 32px);
-  --font-huge: clamp(30px, 4.2vw, 44px);
+  --radius-sm: clamp(6px, 0.8vh, 12px);
+  --radius-md: clamp(9px, 1.2vh, 16px);
+  --radius-lg: clamp(12px, 1.6vh, 22px);
+  --font-base: clamp(12px, 1.6vh, 18px);
+  --font-heading: clamp(13px, 1.9vh, 20px);
+  --font-display: clamp(16px, 2.4vh, 26px);
+  --font-huge: clamp(18px, 3vh, 34px);
 }
 
 *,
@@ -58,10 +58,10 @@ body,
 .app-screen {
   width: 100vw;
   height: 100vh;
-  padding: clamp(10px, 1.6vh, 18px) clamp(14px, 2.4vw, 26px);
+  padding: clamp(12px, 2.2vh, 28px) clamp(14px, 2.8vh, 32px);
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: clamp(10px, 1.2vh, 16px);
+  gap: clamp(8px, 1.6vh, 16px);
   background: var(--bg);
   overflow: hidden;
 }
@@ -74,31 +74,31 @@ body,
   display: grid;
   grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.3fr) minmax(0, 0.25fr);
   align-items: center;
-  gap: clamp(10px, 1.6vw, 18px);
-  padding-bottom: clamp(4px, 0.6vh, 8px);
+  gap: clamp(8px, 1.6vh, 18px);
+  padding-bottom: clamp(4px, 0.8vh, 10px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: clamp(8px, 1.4vw, 18px);
+  gap: clamp(8px, 1.4vh, 18px);
 }
 
 .logo {
   display: grid;
   place-items: center;
-  width: clamp(36px, 4.8vw, 52px);
-  height: clamp(36px, 4.8vw, 52px);
-  border-radius: 16px;
+  width: clamp(32px, 4.6vh, 56px);
+  height: clamp(32px, 4.6vh, 56px);
+  border-radius: clamp(10px, 1.4vh, 18px);
   background: rgba(255, 209, 102, 0.14);
-  font-size: clamp(20px, 3.2vw, 30px);
+  font-size: clamp(16px, 2.8vh, 32px);
 }
 
 .brand-text {
   display: flex;
   flex-direction: column;
-  gap: clamp(2px, 0.4vh, 6px);
+  gap: clamp(2px, 0.6vh, 6px);
 }
 
 .title,
@@ -111,7 +111,7 @@ body,
 
 .subtitle,
 .menu-subtitle {
-  font-size: clamp(12px, 1.4vw, 16px);
+  font-size: clamp(10px, 1.3vh, 14px);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -152,7 +152,7 @@ body,
 .value,
 .denom-value,
 .ticket-price {
-  font-size: clamp(18px, 2.6vw, 28px);
+  font-size: clamp(16px, 2.4vh, 26px);
 }
 
 .panel,
@@ -167,13 +167,13 @@ body,
   background: var(--surface);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
-  padding: clamp(10px, 1.4vh, 14px) clamp(14px, 2.2vw, 20px);
+  padding: clamp(10px, 1.6vh, 16px) clamp(12px, 2.2vh, 20px);
 }
 
 .info-card {
   display: flex;
   flex-direction: column;
-  gap: clamp(6px, 0.8vh, 10px);
+  gap: clamp(4px, 0.8vh, 10px);
   justify-content: center;
 }
 
@@ -182,7 +182,7 @@ body,
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: clamp(6px, 0.8vh, 10px);
+  gap: clamp(4px, 0.8vh, 10px);
 }
 
 .timer-card {
@@ -193,12 +193,12 @@ body,
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: clamp(8px, 1.2vw, 14px);
-  margin-bottom: clamp(4px, 0.6vh, 8px);
+  gap: clamp(6px, 1.2vh, 12px);
+  margin-bottom: clamp(4px, 0.7vh, 9px);
 }
 
 .panel-title {
-  font-size: clamp(14px, 2vw, 20px);
+  font-size: clamp(12px, 1.6vh, 16px);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -206,8 +206,8 @@ body,
 .btn {
   border: none;
   border-radius: var(--radius-md);
-  padding: clamp(8px, 1.2vh, 12px) clamp(14px, 2.2vw, 20px);
-  font-size: var(--font-base);
+  padding: clamp(8px, 1.4vh, 14px) clamp(12px, 2.4vh, 20px);
+  font-size: clamp(12px, 1.6vh, 18px);
   font-weight: 700;
   background: var(--surface-subtle);
   color: var(--text-primary);
@@ -256,7 +256,7 @@ select {
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: var(--radius-md);
   background: var(--surface-subtle);
-  padding: clamp(8px, 1.2vh, 12px) clamp(12px, 2vw, 18px);
+  padding: clamp(8px, 1.2vh, 12px) clamp(10px, 2vh, 18px);
   color: var(--text-primary);
 }
 
@@ -276,17 +276,17 @@ button:focus-visible {
   flex-direction: column;
   gap: clamp(4px, 0.6vh, 8px);
   overflow-y: auto;
-  padding-right: clamp(2px, 0.4vw, 6px);
+  padding-right: clamp(2px, 0.4vh, 6px);
 }
 
 .history-list .item {
   background: var(--surface-subtle);
   border-radius: var(--radius-sm);
-  padding: clamp(6px, 1vh, 10px) clamp(8px, 1.2vw, 12px);
+  padding: clamp(6px, 1vh, 10px) clamp(8px, 1.6vh, 12px);
   display: flex;
   justify-content: space-between;
-  gap: clamp(4px, 0.8vw, 10px);
-  font-size: var(--font-base);
+  gap: clamp(4px, 0.8vh, 10px);
+  font-size: clamp(11px, 1.5vh, 16px);
 }
 
 .menu-screen {

--- a/styles/game.css
+++ b/styles/game.css
@@ -1,11 +1,11 @@
-
 .game-screen {
-  grid-template-rows: 0.13fr 0.62fr 0.25fr;
+  grid-template-rows: 0.14fr 0.17fr 0.36fr 0.22fr 0.11fr;
+  gap: clamp(8px, 1.6vh, 16px);
 }
 
 .game-top {
   border-bottom: none;
-  grid-template-columns: minmax(0, 0.36fr) minmax(0, 0.28fr) minmax(0, 0.36fr);
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 0.32fr) minmax(0, 0.26fr);
 }
 
 .game-top .stat-card,
@@ -16,21 +16,7 @@
 
 .game-top .stat-card .value,
 .game-top .timer {
-  font-size: clamp(22px, 3.2vw, 34px);
-}
-
-.game-content {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(10px, 1.6vw, 18px);
-  min-height: 0;
-}
-
-.game-column {
-  display: grid;
-  grid-template-rows: minmax(0, 0.42fr) minmax(0, 0.58fr);
-  gap: clamp(10px, 1.2vh, 14px);
-  min-height: 0;
+  font-size: clamp(18px, 2.6vh, 30px);
 }
 
 .needs-panel,
@@ -40,14 +26,18 @@
 .action-panel {
   display: flex;
   flex-direction: column;
-  gap: clamp(8px, 1vh, 12px);
+  gap: clamp(6px, 1.2vh, 12px);
   min-height: 0;
+}
+
+.hud-panel {
+  justify-content: center;
 }
 
 .needs-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: clamp(8px, 1vh, 12px);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(8px, 1.4vh, 14px);
   min-height: 0;
 }
 
@@ -63,71 +53,56 @@
   justify-content: space-between;
 }
 
-
-.tickets-track {
+.grid-tickets {
   flex: 1;
-  display: flex;
-  gap: clamp(10px, 1.4vw, 16px);
-  align-items: stretch;
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding-bottom: clamp(4px, 0.6vh, 8px);
-  scroll-snap-type: x proximity;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  gap: clamp(8px, 1.6vh, 16px);
+  min-height: 0;
 }
-
-.tickets-track::-webkit-scrollbar {
-  height: clamp(4px, 0.6vh, 6px);
-}
-
-.tickets-track::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-}
-
 
 .ticket-btn {
   position: relative;
-  flex: 0 0 auto;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 0.8vh, 8px);
+  gap: clamp(4px, 0.8vh, 10px);
   text-align: center;
   border: none;
-  border-radius: var(--radius-md);
-  padding: clamp(8px, 1.2vh, 12px);
-  width: clamp(100px, 15vw, 150px);
-  height: min(15vh, 22vw);
+  border-radius: clamp(10px, 1.4vh, 18px);
+  padding: clamp(8px, 1.4vh, 14px);
   color: #101820;
   box-shadow: 0 0.4vh 1.2vh rgba(0, 0, 0, 0.25);
-  scroll-snap-align: center;
 }
 
 .ticket-btn .ticket-icon {
-  font-size: clamp(18px, 2.8vw, 26px);
+  font-size: clamp(16px, 2.4vh, 26px);
 }
 
 .ticket-btn .sub {
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  font-size: clamp(11px, 1.2vw, 14px);
+  font-size: clamp(11px, 1.6vh, 16px);
 }
 
 .ticket-btn .ticket-price {
-  font-size: clamp(16px, 2.2vw, 22px);
+  font-size: clamp(14px, 2vh, 22px);
 }
 
 .ticket-btn .bubble {
   position: absolute;
-  top: clamp(4px, 0.6vh, 8px);
-  right: clamp(4px, 0.8vw, 8px);
-  padding: clamp(3px, 0.5vh, 6px) clamp(6px, 1vw, 10px);
+  top: clamp(4px, 0.7vh, 8px);
+  right: clamp(4px, 0.8vh, 8px);
+  padding: clamp(3px, 0.5vh, 6px) clamp(6px, 1vh, 10px);
   border-radius: 999px;
   background: rgba(16, 24, 32, 0.75);
   color: #f4f7fb;
-  font-size: clamp(11px, 1.2vw, 14px);
+  font-size: clamp(10px, 1.4vh, 14px);
   font-weight: 700;
 }
 
@@ -170,7 +145,7 @@
 .change-summary {
   display: inline-flex;
   align-items: baseline;
-  gap: clamp(6px, 0.8vw, 10px);
+  gap: clamp(4px, 1vh, 10px);
 }
 
 .change-value {
@@ -200,49 +175,82 @@
 
 .currency-grid {
   flex: 1;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-content: space-evenly;
-  gap: clamp(10px, 1.4vw, 16px);
-  padding-block: clamp(4px, 0.6vh, 8px);
+  display: grid;
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
+  gap: clamp(8px, 1.4vh, 14px);
+  min-height: 0;
+}
+
+.coins-row {
+  display: grid;
+  gap: inherit;
+}
+
+.coins-row.bills {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.coins-row.coins {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
 .currency-btn {
   position: relative;
-  display: grid;
-  place-items: center;
-  gap: clamp(2px, 0.4vh, 4px);
-  width: min(9vh, 9vw);
-  height: min(9vh, 9vw);
-  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(2px, 0.6vh, 6px);
   border: none;
   background: #f6d186;
   color: #101820;
   box-shadow: 0 0.4vh 1.2vh rgba(0, 0, 0, 0.35);
   text-align: center;
-  padding: clamp(5px, 0.7vh, 8px);
+  padding: clamp(5px, 1vh, 10px);
+}
+
+.currency-btn.coin {
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+}
+
+.currency-btn.bill {
+  aspect-ratio: 7 / 4;
+  border-radius: clamp(10px, 1.2vh, 16px);
 }
 
 .currency-btn .denom-icon {
-  font-size: clamp(14px, 2vw, 18px);
-  opacity: 0.65;
+  font-size: clamp(12px, 1.6vh, 18px);
+  opacity: 0.7;
 }
 
 .currency-btn .denom-value {
-  font-size: clamp(15px, 2.2vw, 20px);
+  font-size: clamp(14px, 1.9vh, 20px);
 }
 
 .currency-btn .denom-label {
-  font-size: clamp(11px, 1.2vw, 14px);
+  font-size: clamp(10px, 1.3vh, 13px);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(16, 24, 32, 0.6);
 }
 
-.currency-btn.skin-blue {
-  background: #70c2ff;
-  color: #0b1c2c;
+.currency-btn.skin-bill {
+  background: linear-gradient(160deg, #7fd4ff 0%, #b3e7ff 100%);
+  color: #082033;
+}
+
+.currency-btn.skin-bill-alt {
+  background: linear-gradient(160deg, #8fe3c1 0%, #b9f0d7 100%);
+  color: #0f2a25;
+}
+
+.currency-btn.skin-bill-soft {
+  background: linear-gradient(160deg, #ffe59f 0%, #fff1c4 100%);
+  color: #2a1f0c;
 }
 
 .currency-btn.skin-gold {
@@ -270,10 +278,10 @@
   color: #1b1f24;
 }
 
-.bottom-bar {
+.history-row {
   display: grid;
-  grid-template-columns: minmax(0, 0.68fr) minmax(0, 0.32fr);
-  gap: clamp(10px, 1.6vw, 18px);
+  grid-template-columns: minmax(0, 0.64fr) minmax(0, 0.36fr);
+  gap: clamp(8px, 1.6vh, 16px);
   min-height: 0;
 }
 
@@ -296,30 +304,22 @@
 
 @media (max-width: 1100px) {
   .needs-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .grid-tickets {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .coins-row.bills {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .coins-row.coins {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .history-row {
     grid-template-columns: 1fr;
-  }
-
-  .ticket-btn {
-    width: clamp(90px, 24vw, 150px);
-  }
-}
-
-@media (max-width: 900px) {
-  .game-screen {
-    grid-template-rows: 0.16fr 0.6fr 0.24fr;
-  }
-
-  .game-content {
-    grid-template-columns: 1fr;
-    grid-template-rows: repeat(2, minmax(0, 1fr));
-  }
-
-  .game-column {
-    grid-template-rows: minmax(0, 0.5fr) minmax(0, 0.5fr);
-  }
-
-  .bottom-bar {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(0, 0.7fr) minmax(0, 0.3fr);
   }
 }


### PR DESCRIPTION
## Summary
- restructure the game screen into a five-row grid so header, HUD, tickets, payment, and history/action areas stay within the stage without scrolling
- rework ticket and payment controls into fixed grids with vh-based clamps so eight tickets, three bills, and five coins remain visible and legible in landscape
- retune typography/padding clamps and currency constants to provide proportional sizing and updated bill/coin sets

## Testing
- Manual: Verified game.html on iPhone 16 Pro Max landscape (Playwright)
- Manual: Verified game.html on Pixel 7 landscape (Playwright)

## Screenshots
![iPhone 16 Pro Max landscape](browser:/invocations/uechtoxu/artifacts/artifacts/iphone16-promax-landscape.png)
![Pixel 7 landscape](browser:/invocations/enfzvyyi/artifacts/artifacts/pixel7-landscape.png)

------
https://chatgpt.com/codex/tasks/task_b_68d7a716d8608329b283c6e312e39a3c