### PR TITLE
Tighten ticket and payment sizing for landscape play

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -12,10 +12,10 @@
   --radius-sm: clamp(6px, 0.8vh, 12px);
   --radius-md: clamp(9px, 1.2vh, 16px);
   --radius-lg: clamp(12px, 1.6vh, 22px);
-  --font-base: clamp(12px, 1.6vh, 18px);
-  --font-heading: clamp(13px, 1.9vh, 20px);
-  --font-display: clamp(16px, 2.4vh, 26px);
-  --font-huge: clamp(18px, 3vh, 34px);
+  --font-base: clamp(12px, 1.8vh, 20px);
+  --font-heading: var(--font-base);
+  --font-display: var(--font-base);
+  --font-huge: var(--font-base);
 }
 
 *,
@@ -58,10 +58,13 @@ body,
 .app-screen {
   width: 100vw;
   height: 100vh;
-  padding: clamp(12px, 2.2vh, 28px) clamp(14px, 2.8vh, 32px);
+  --app-pad-x: clamp(12px, 2.4vh, 26px);
+  padding: clamp(10px, 1.8vh, 22px) var(--app-pad-x);
+  padding-left: calc(var(--app-pad-x) + env(safe-area-inset-left, 0px));
+  padding-right: calc(var(--app-pad-x) + env(safe-area-inset-right, 0px));
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: clamp(8px, 1.6vh, 16px);
+  gap: clamp(6px, 1.2vh, 12px);
   background: var(--bg);
   overflow: hidden;
 }
@@ -74,25 +77,25 @@ body,
   display: grid;
   grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.3fr) minmax(0, 0.25fr);
   align-items: center;
-  gap: clamp(8px, 1.6vh, 18px);
-  padding-bottom: clamp(4px, 0.8vh, 10px);
+  gap: clamp(6px, 1.2vh, 12px);
+  padding-bottom: clamp(4px, 0.7vh, 8px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: clamp(8px, 1.4vh, 18px);
+  gap: clamp(6px, 1.1vh, 12px);
 }
 
 .logo {
   display: grid;
   place-items: center;
-  width: clamp(32px, 4.6vh, 56px);
-  height: clamp(32px, 4.6vh, 56px);
-  border-radius: clamp(10px, 1.4vh, 18px);
+  width: clamp(26px, 3.6vh, 44px);
+  height: clamp(26px, 3.6vh, 44px);
+  border-radius: clamp(8px, 1.2vh, 14px);
   background: rgba(255, 209, 102, 0.14);
-  font-size: clamp(16px, 2.8vh, 32px);
+  font-size: var(--font-base);
 }
 
 .brand-text {
@@ -111,7 +114,7 @@ body,
 
 .subtitle,
 .menu-subtitle {
-  font-size: clamp(10px, 1.3vh, 14px);
+  font-size: var(--font-base);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -152,7 +155,7 @@ body,
 .value,
 .denom-value,
 .ticket-price {
-  font-size: clamp(16px, 2.4vh, 26px);
+  font-size: var(--font-display);
 }
 
 .panel,
@@ -167,13 +170,13 @@ body,
   background: var(--surface);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
-  padding: clamp(10px, 1.6vh, 16px) clamp(12px, 2.2vh, 20px);
+  padding: clamp(8px, 1.2vh, 14px) clamp(10px, 1.8vh, 16px);
 }
 
 .info-card {
   display: flex;
   flex-direction: column;
-  gap: clamp(4px, 0.8vh, 10px);
+  gap: clamp(3px, 0.7vh, 8px);
   justify-content: center;
 }
 
@@ -182,7 +185,7 @@ body,
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: clamp(4px, 0.8vh, 10px);
+  gap: clamp(3px, 0.7vh, 8px);
 }
 
 .timer-card {
@@ -193,12 +196,12 @@ body,
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: clamp(6px, 1.2vh, 12px);
-  margin-bottom: clamp(4px, 0.7vh, 9px);
+  gap: clamp(4px, 0.8vh, 10px);
+  margin-bottom: clamp(3px, 0.6vh, 8px);
 }
 
 .panel-title {
-  font-size: clamp(12px, 1.6vh, 16px);
+  font-size: var(--font-heading);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -206,8 +209,8 @@ body,
 .btn {
   border: none;
   border-radius: var(--radius-md);
-  padding: clamp(8px, 1.4vh, 14px) clamp(12px, 2.4vh, 20px);
-  font-size: clamp(12px, 1.6vh, 18px);
+  padding: clamp(6px, 1vh, 12px) clamp(10px, 1.6vh, 16px);
+  font-size: var(--font-base);
   font-weight: 700;
   background: var(--surface-subtle);
   color: var(--text-primary);
@@ -274,19 +277,19 @@ button:focus-visible {
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: clamp(4px, 0.6vh, 8px);
+  gap: clamp(3px, 0.6vh, 6px);
   overflow-y: auto;
-  padding-right: clamp(2px, 0.4vh, 6px);
+  padding-right: clamp(2px, 0.3vh, 4px);
 }
 
 .history-list .item {
   background: var(--surface-subtle);
   border-radius: var(--radius-sm);
-  padding: clamp(6px, 1vh, 10px) clamp(8px, 1.6vh, 12px);
+  padding: clamp(5px, 0.9vh, 9px) clamp(7px, 1.3vh, 10px);
   display: flex;
   justify-content: space-between;
-  gap: clamp(4px, 0.8vh, 10px);
-  font-size: clamp(11px, 1.5vh, 16px);
+  gap: clamp(3px, 0.6vh, 8px);
+  font-size: var(--font-base);
 }
 
 .menu-screen {

--- a/styles/game.css
+++ b/styles/game.css
@@ -1,11 +1,20 @@
 .game-screen {
-  grid-template-rows: 0.14fr 0.17fr 0.36fr 0.22fr 0.11fr;
-  gap: clamp(8px, 1.6vh, 16px);
+  --ticket-scale: 0.7;
+  --currency-scale: 0.45;
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+  grid-template-rows: auto minmax(0, 0.42fr) minmax(0, 0.32fr) minmax(0, 0.26fr);
+  grid-template-areas:
+    'top top'
+    'needs payment'
+    'tickets payment'
+    'history history';
+  gap: clamp(6px, 1.2vh, 12px);
 }
 
 .game-top {
   border-bottom: none;
-  grid-template-columns: minmax(0, 0.42fr) minmax(0, 0.32fr) minmax(0, 0.26fr);
+  grid-area: top;
+  grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.28fr) minmax(0, 0.27fr);
 }
 
 .game-top .stat-card,
@@ -16,7 +25,7 @@
 
 .game-top .stat-card .value,
 .game-top .timer {
-  font-size: clamp(18px, 2.6vh, 30px);
+  font-size: var(--font-display);
 }
 
 .needs-panel,
@@ -26,7 +35,7 @@
 .action-panel {
   display: flex;
   flex-direction: column;
-  gap: clamp(6px, 1.2vh, 12px);
+  gap: clamp(4px, 0.8vh, 10px);
   min-height: 0;
 }
 
@@ -34,10 +43,14 @@
   justify-content: center;
 }
 
+.needs-panel {
+  grid-area: needs;
+}
+
 .needs-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: clamp(8px, 1.4vh, 14px);
+  gap: clamp(4px, 0.8vh, 10px);
   min-height: 0;
 }
 
@@ -50,6 +63,7 @@
 }
 
 .tickets-panel {
+  grid-area: tickets;
   justify-content: space-between;
 }
 
@@ -58,51 +72,54 @@
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-auto-rows: 1fr;
-  gap: clamp(8px, 1.6vh, 16px);
+  gap: clamp(4px, 0.8vh, 10px);
   min-height: 0;
+  place-items: center;
 }
 
 .ticket-btn {
   position: relative;
-  width: 100%;
-  height: 100%;
+  width: calc(100% * var(--ticket-scale));
+  height: calc(100% * var(--ticket-scale));
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(4px, 0.8vh, 10px);
+  gap: calc(clamp(3px, 0.6vh, 8px) * var(--ticket-scale));
   text-align: center;
   border: none;
-  border-radius: clamp(10px, 1.4vh, 18px);
-  padding: clamp(8px, 1.4vh, 14px);
+  border-radius: calc(clamp(10px, 1.4vh, 18px) * var(--ticket-scale));
+  padding: calc(clamp(6px, 1vh, 12px) * var(--ticket-scale));
   color: #101820;
   box-shadow: 0 0.4vh 1.2vh rgba(0, 0, 0, 0.25);
+  margin: 0 auto;
 }
 
 .ticket-btn .ticket-icon {
-  font-size: clamp(16px, 2.4vh, 26px);
+  font-size: var(--font-display);
 }
 
 .ticket-btn .sub {
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  font-size: clamp(11px, 1.6vh, 16px);
+  font-size: var(--font-base);
 }
 
 .ticket-btn .ticket-price {
-  font-size: clamp(14px, 2vh, 22px);
+  font-size: var(--font-display);
 }
 
 .ticket-btn .bubble {
   position: absolute;
-  top: clamp(4px, 0.7vh, 8px);
-  right: clamp(4px, 0.8vh, 8px);
-  padding: clamp(3px, 0.5vh, 6px) clamp(6px, 1vh, 10px);
+  top: calc(clamp(4px, 0.7vh, 8px) * var(--ticket-scale));
+  right: calc(clamp(4px, 0.8vh, 8px) * var(--ticket-scale));
+  padding: calc(clamp(3px, 0.5vh, 6px) * var(--ticket-scale))
+    calc(clamp(6px, 1vh, 10px) * var(--ticket-scale));
   border-radius: 999px;
   background: rgba(16, 24, 32, 0.75);
   color: #f4f7fb;
-  font-size: clamp(10px, 1.4vh, 14px);
+  font-size: var(--font-base);
   font-weight: 700;
 }
 
@@ -164,6 +181,10 @@
   color: #6ce5b1;
 }
 
+.change-panel {
+  grid-area: payment;
+}
+
 .change-panel[data-visible='false'] .currency-grid,
 .change-panel[data-visible='false'] .change-summary {
   opacity: 0.45;
@@ -178,13 +199,17 @@
   display: grid;
   grid-template-rows: repeat(2, minmax(0, 1fr));
   grid-template-columns: 1fr;
-  gap: clamp(8px, 1.4vh, 14px);
+  gap: clamp(4px, 0.8vh, 10px);
   min-height: 0;
+  justify-items: center;
 }
 
 .coins-row {
   display: grid;
+  align-items: stretch;
+  justify-items: center;
   gap: inherit;
+  min-height: 0;
 }
 
 .coins-row.bills {
@@ -197,19 +222,19 @@
 
 .currency-btn {
   position: relative;
-  width: 100%;
-  height: 100%;
+  width: calc(100% * var(--currency-scale));
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(2px, 0.6vh, 6px);
+  gap: calc(clamp(2px, 0.5vh, 6px) * var(--currency-scale));
   border: none;
   background: #f6d186;
   color: #101820;
   box-shadow: 0 0.4vh 1.2vh rgba(0, 0, 0, 0.35);
   text-align: center;
-  padding: clamp(5px, 1vh, 10px);
+  padding: calc(clamp(4px, 0.8vh, 8px) * var(--currency-scale));
+  margin: 0 auto;
 }
 
 .currency-btn.coin {
@@ -219,20 +244,20 @@
 
 .currency-btn.bill {
   aspect-ratio: 7 / 4;
-  border-radius: clamp(10px, 1.2vh, 16px);
+  border-radius: calc(clamp(10px, 1.2vh, 16px) * var(--currency-scale));
 }
 
 .currency-btn .denom-icon {
-  font-size: clamp(12px, 1.6vh, 18px);
+  font-size: var(--font-base);
   opacity: 0.7;
 }
 
 .currency-btn .denom-value {
-  font-size: clamp(14px, 1.9vh, 20px);
+  font-size: var(--font-display);
 }
 
 .currency-btn .denom-label {
-  font-size: clamp(10px, 1.3vh, 13px);
+  font-size: var(--font-base);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(16, 24, 32, 0.6);
@@ -278,14 +303,19 @@
   color: #1b1f24;
 }
 
+
 .history-row {
+  grid-area: history;
   display: grid;
-  grid-template-columns: minmax(0, 0.64fr) minmax(0, 0.36fr);
-  gap: clamp(8px, 1.6vh, 16px);
+  grid-template-columns: minmax(0, 0.66fr) minmax(0, 0.34fr);
+  gap: clamp(6px, 1.1vh, 12px);
   min-height: 0;
+  align-items: stretch;
 }
 
 .history-panel {
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
@@ -294,32 +324,30 @@
 }
 
 .action-panel {
-  justify-content: space-between;
-  align-items: stretch;
+  display: grid;
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+  gap: clamp(4px, 0.8vh, 10px);
+  justify-content: stretch;
 }
 
 .action-panel .btn {
   width: 100%;
+  min-height: 0;
 }
 
 @media (max-width: 1100px) {
-  .needs-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .grid-tickets {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .coins-row.bills {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .coins-row.coins {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+  .game-screen {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 0.42fr) minmax(0, 0.42fr) minmax(0, 0.28fr) minmax(0, 0.24fr);
+    grid-template-areas:
+      'top'
+      'needs'
+      'tickets'
+      'payment'
+      'history';
   }
 
   .history-row {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 0.6fr) minmax(0, 0.4fr);
   }
 }


### PR DESCRIPTION
## Summary
- shrink ticket grid cards to 70% of their cells and scale internal spacing so the matrix fits within the landscape viewport
- scale bill and coin controls to 45% of their slots and center them with proportional padding to eliminate overlap
- add horizontal safe-area padding to respect iPhone notches in landscape

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68d7aa0ea6e483299e241c04e5b5a1d5