### PR TITLE
Reduce game UI scale for landscape fit

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -8,11 +8,11 @@
   --text-primary: #f4f7fb;
   --text-muted: #92a4b8;
   --accent: #ffd166;
-  --shadow-soft: 0 0.8vh 2vh rgba(0, 0, 0, 0.35);
-  --radius-sm: clamp(6px, 0.8vh, 12px);
-  --radius-md: clamp(9px, 1.2vh, 16px);
-  --radius-lg: clamp(12px, 1.6vh, 22px);
-  --font-base: clamp(12px, 1.8vh, 20px);
+  --shadow-soft: 0 0.5vh 1.2vh rgba(0, 0, 0, 0.35);
+  --radius-sm: clamp(4px, 0.6vh, 8px);
+  --radius-md: clamp(6px, 0.8vh, 12px);
+  --radius-lg: clamp(8px, 1.1vh, 16px);
+  --font-base: clamp(10px, 1.4vh, 16px);
   --font-heading: var(--font-base);
   --font-display: var(--font-base);
   --font-huge: var(--font-base);
@@ -59,14 +59,14 @@ body,
   width: 100vw;
   height: 100vh;
 
-  --app-pad-x: clamp(12px, 2.4vh, 26px);
-  padding: clamp(10px, 1.8vh, 22px) var(--app-pad-x);
+  --app-pad-x: clamp(8px, 1.6vh, 18px);
+  padding: clamp(6px, 1.2vh, 14px) var(--app-pad-x);
   padding-left: calc(var(--app-pad-x) + env(safe-area-inset-left, 0px));
   padding-right: calc(var(--app-pad-x) + env(safe-area-inset-right, 0px));
 
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: clamp(6px, 1.2vh, 12px);
+  gap: clamp(4px, 0.8vh, 9px);
   background: var(--bg);
   overflow: hidden;
 }
@@ -79,23 +79,23 @@ body,
   display: grid;
   grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.3fr) minmax(0, 0.25fr);
   align-items: center;
-  gap: clamp(6px, 1.2vh, 12px);
-  padding-bottom: clamp(4px, 0.7vh, 8px);
+  gap: clamp(4px, 0.8vh, 9px);
+  padding-bottom: clamp(3px, 0.6vh, 6px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: clamp(6px, 1.1vh, 12px);
+  gap: clamp(4px, 0.8vh, 9px);
 }
 
 .logo {
   display: grid;
   place-items: center;
-  width: clamp(26px, 3.6vh, 44px);
-  height: clamp(26px, 3.6vh, 44px);
-  border-radius: clamp(8px, 1.2vh, 14px);
+  width: clamp(20px, 2.8vh, 32px);
+  height: clamp(20px, 2.8vh, 32px);
+  border-radius: clamp(6px, 0.9vh, 10px);
   background: rgba(255, 209, 102, 0.14);
   font-size: var(--font-base);
 }
@@ -103,7 +103,7 @@ body,
 .brand-text {
   display: flex;
   flex-direction: column;
-  gap: clamp(2px, 0.6vh, 6px);
+  gap: clamp(1px, 0.4vh, 4px);
 }
 
 .title,
@@ -172,7 +172,7 @@ body,
   background: var(--surface);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
-  padding: clamp(8px, 1.2vh, 14px) clamp(10px, 1.8vh, 16px);
+  padding: clamp(5px, 0.9vh, 10px) clamp(7px, 1.2vh, 12px);
 }
 
 .info-card {

--- a/styles/game.css
+++ b/styles/game.css
@@ -7,7 +7,7 @@
     'needs payment'
     'tickets payment'
     'history history';
-  gap: clamp(6px, 1.2vh, 12px);
+  gap: clamp(4px, 0.8vh, 9px);
 }
 
 .game-top {
@@ -34,7 +34,7 @@
 .action-panel {
   display: flex;
   flex-direction: column;
-  gap: clamp(4px, 0.8vh, 10px);
+  gap: clamp(3px, 0.6vh, 7px);
   min-height: 0;
 }
 
@@ -49,7 +49,7 @@
 .needs-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: clamp(4px, 0.8vh, 10px);
+  gap: clamp(3px, 0.6vh, 7px);
   min-height: 0;
 }
 
@@ -71,7 +71,7 @@
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-rows: repeat(2, minmax(0, 1fr));
-  gap: clamp(4px, 0.7vh, 9px);
+  gap: clamp(3px, 0.6vh, 7px);
   min-height: 0;
   align-content: stretch;
   justify-items: stretch;
@@ -80,46 +80,46 @@
 .ticket-btn {
   position: relative;
   width: 100%;
-  max-width: clamp(96px, 19vw, 140px);
+  max-width: clamp(40px, 8vw, 64px);
   aspect-ratio: 5 / 6;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(3px, 0.7vh, 8px);
+  gap: clamp(2px, 0.4vh, 5px);
   text-align: center;
   border: none;
-  border-radius: clamp(10px, 1.3vh, 16px);
-  padding: clamp(7px, 1.2vh, 11px) clamp(6px, 1.1vh, 9px);
+  border-radius: clamp(6px, 0.9vh, 10px);
+  padding: clamp(3px, 0.6vh, 6px) clamp(3px, 0.6vh, 5px);
   color: #101820;
-  box-shadow: 0 0.35vh 1vh rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0.22vh 0.7vh rgba(0, 0, 0, 0.25);
   margin: 0 auto;
 }
 
 .ticket-btn .ticket-icon {
-  font-size: clamp(18px, 3vh, 28px);
+  font-size: clamp(12px, 2vh, 20px);
 }
 
 .ticket-btn .sub {
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  font-size: clamp(11px, 1.5vh, 15px);
+  font-size: clamp(8px, 1.1vh, 12px);
 }
 
 .ticket-btn .ticket-price {
-  font-size: clamp(14px, 2vh, 20px);
+  font-size: clamp(10px, 1.4vh, 14px);
 }
 
 .ticket-btn .bubble {
   position: absolute;
-  top: clamp(6px, 1vh, 9px);
-  right: clamp(6px, 1vh, 9px);
-  padding: clamp(2px, 0.5vh, 5px) clamp(5px, 0.9vh, 8px);
+  top: clamp(4px, 0.7vh, 6px);
+  right: clamp(4px, 0.7vh, 6px);
+  padding: clamp(1px, 0.3vh, 3px) clamp(3px, 0.6vh, 5px);
   border-radius: 999px;
   background: rgba(16, 24, 32, 0.75);
   color: #f4f7fb;
-  font-size: clamp(10px, 1.4vh, 14px);
+  font-size: clamp(8px, 1.1vh, 11px);
   font-weight: 700;
 }
 
@@ -199,7 +199,7 @@
   display: grid;
   grid-template-rows: repeat(2, minmax(0, 1fr));
   grid-template-columns: 1fr;
-  gap: clamp(4px, 0.8vh, 9px);
+  gap: clamp(3px, 0.6vh, 7px);
   min-height: 0;
   justify-items: center;
   align-content: center;
@@ -209,7 +209,7 @@
   display: grid;
   align-items: stretch;
   justify-items: center;
-  gap: clamp(4px, 0.8vh, 9px);
+  gap: clamp(3px, 0.6vh, 7px);
   min-height: 0;
 }
 
@@ -224,44 +224,44 @@
 .currency-btn {
   position: relative;
   width: 100%;
-  max-width: clamp(88px, 16vw, 140px);
+  max-width: clamp(36px, 7vw, 60px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(2px, 0.6vh, 6px);
+  gap: clamp(1px, 0.4vh, 4px);
   border: none;
   background: #f6d186;
   color: #101820;
-  box-shadow: 0 0.4vh 1.2vh rgba(0, 0, 0, 0.35);
+  box-shadow: 0 0.22vh 0.7vh rgba(0, 0, 0, 0.35);
   text-align: center;
-  padding: clamp(5px, 1vh, 9px) clamp(6px, 1.1vh, 10px);
+  padding: clamp(2px, 0.4vh, 4px) clamp(3px, 0.6vh, 5px);
   margin: 0 auto;
 }
 
 .currency-btn.coin {
   aspect-ratio: 1 / 1;
   border-radius: 50%;
-  max-width: clamp(56px, 10vw, 88px);
+  max-width: clamp(30px, 5.4vw, 44px);
 }
 
 .currency-btn.bill {
   aspect-ratio: 7 / 4;
-  border-radius: clamp(9px, 1.1vh, 14px);
-  max-width: clamp(100px, 18vw, 156px);
+  border-radius: clamp(6px, 0.9vh, 10px);
+  max-width: clamp(52px, 10vw, 84px);
 }
 
 .currency-btn .denom-icon {
-  font-size: clamp(11px, 1.5vh, 14px);
+  font-size: clamp(7px, 1vh, 11px);
   opacity: 0.7;
 }
 
 .currency-btn .denom-value {
-  font-size: clamp(13px, 1.9vh, 18px);
+  font-size: clamp(9px, 1.3vh, 13px);
 }
 
 .currency-btn .denom-label {
-  font-size: clamp(10px, 1.4vh, 13px);
+  font-size: clamp(7px, 1vh, 11px);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(16, 24, 32, 0.6);
@@ -312,7 +312,7 @@
   grid-area: history;
   display: grid;
   grid-template-columns: minmax(0, 0.66fr) minmax(0, 0.34fr);
-  gap: clamp(4px, 0.8vh, 9px);
+  gap: clamp(3px, 0.6vh, 7px);
   min-height: 0;
   align-items: stretch;
 }
@@ -321,7 +321,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  padding: clamp(6px, 1vh, 11px) clamp(8px, 1.4vh, 12px);
+  padding: clamp(4px, 0.7vh, 8px) clamp(5px, 0.9vh, 9px);
 }
 
 .history-list {
@@ -331,15 +331,15 @@
 .action-panel {
   display: grid;
   grid-template-rows: repeat(3, minmax(0, 1fr));
-  gap: clamp(4px, 0.7vh, 8px);
+  gap: clamp(3px, 0.6vh, 6px);
   justify-content: stretch;
-  padding: clamp(6px, 1vh, 11px) clamp(8px, 1.4vh, 12px);
+  padding: clamp(4px, 0.7vh, 8px) clamp(5px, 0.9vh, 9px);
 }
 
 .action-panel .btn {
   width: 100%;
   min-height: 0;
-  font-size: clamp(12px, 1.6vh, 18px);
+  font-size: clamp(9px, 1.3vh, 14px);
 }
 
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
- tighten global typography, radii, and padding so screens scale down appropriately
- resize ticket tiles and currency controls with clamp-based sizing to keep the grid visible in landscape
- reduce history and action panel spacing to preserve the footer controls without overlap

## Testing
- Manual QA: Loaded http://127.0.0.1:8000/game.html

------
https://chatgpt.com/codex/tasks/task_b_68d7de8b93508329823bc69c71267ebb