### PR TITLE
Refine game screen layout for fixed ticket and payment rows

### DIFF
--- a/game.html
+++ b/game.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+  />
   <title>Ticket Rush PRO — Game</title>
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -29,6 +32,9 @@
         <span class="label">Timer</span>
         <span class="timer" id="timer">20 s</span>
       </div>
+      <button class="btn icon ghost" id="closeGame" type="button" aria-label="Exit to menu">
+        ×
+      </button>
     </header>
 
     <section class="panel needs-panel hud-panel" aria-label="Passenger needs">
@@ -58,6 +64,7 @@
     <section class="panel tickets-panel" aria-label="Tickets">
       <div class="panel-header">
         <span class="panel-title">Tickets</span>
+        <button class="btn ghost" id="clearTickets" type="button">Clear</button>
       </div>
       <div class="grid-tickets" id="tickets"></div>
     </section>
@@ -71,20 +78,6 @@
         </div>
       </div>
       <div class="currency-grid grid-coins" id="coins"></div>
-    </section>
-
-    <section class="history-row" aria-label="Round history and actions">
-      <section class="panel history-panel" aria-label="History">
-        <div class="panel-header">
-          <span class="panel-title">History</span>
-        </div>
-        <div class="history-list" id="history"></div>
-      </section>
-      <div class="panel action-panel" role="group" aria-label="Game controls">
-        <button class="btn ghost" id="clearTickets" type="button">Clear</button>
-        <button class="btn secondary" id="restartGame" type="button">Restart</button>
-        <button class="btn secondary" id="menuButton" type="button">Menu</button>
-      </div>
     </section>
   </main>
 

--- a/js/screens/game.js
+++ b/js/screens/game.js
@@ -22,7 +22,6 @@ const elements = {
   remainEl: document.getElementById('remain'),
   ticketsWrap: document.getElementById('tickets'),
   coinsWrap: document.getElementById('coins'),
-  historyList: document.getElementById('history'),
   changeWrap: document.querySelector('.pay'),
 };
 
@@ -32,8 +31,7 @@ const overlayElements = {
 };
 
 const clearButton = document.getElementById('clearTickets');
-const restartButton = document.getElementById('restartGame');
-const menuButton = document.getElementById('menuButton');
+const closeButton = document.getElementById('closeGame');
 
 let roundActive = false;
 let finishing = false;
@@ -163,15 +161,8 @@ if (clearButton) {
   });
 }
 
-if (restartButton) {
-  restartButton.addEventListener('click', () => {
-    stopRound();
-    window.location.reload();
-  });
-}
-
-if (menuButton) {
-  menuButton.addEventListener('click', () => {
+if (closeButton) {
+  closeButton.addEventListener('click', () => {
     stopRound();
     navigateToMenu();
   });

--- a/styles/app.css
+++ b/styles/app.css
@@ -29,6 +29,8 @@ body {
   height: 100%;
   width: 100%;
   overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
 }
 
 body {
@@ -39,11 +41,6 @@ body {
   color: var(--text-primary);
   background: var(--bg);
   -webkit-font-smoothing: antialiased;
-}
-
-body,
-.app-screen {
-  touch-action: manipulation;
 }
 
 .app-body {
@@ -208,6 +205,11 @@ body,
   text-transform: uppercase;
 }
 
+.panel-header .btn {
+  padding: clamp(4px, 0.7vh, 8px) clamp(8px, 1.4vh, 12px);
+  font-size: clamp(10px, 1.4vh, 15px);
+}
+
 .btn {
   border: none;
   border-radius: var(--radius-md);
@@ -219,6 +221,18 @@ body,
   box-shadow: var(--shadow-soft);
   cursor: pointer;
   transition: transform 0.16s ease, box-shadow 0.16s ease;
+  touch-action: manipulation;
+}
+
+.btn.icon {
+  display: grid;
+  place-items: center;
+  padding: 0;
+  width: clamp(28px, 3vh, 36px);
+  height: clamp(28px, 3vh, 36px);
+  font-size: clamp(18px, 2.4vh, 24px);
+  line-height: 1;
+  border-radius: var(--radius-md);
 }
 
 .btn:active {

--- a/styles/game.css
+++ b/styles/game.css
@@ -1,19 +1,20 @@
 .game-screen {
-  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
-  grid-template-rows: auto minmax(0, 0.42fr) minmax(0, 0.32fr) minmax(0, 0.26fr);
+  grid-template-columns: 1fr;
+  grid-template-rows: auto minmax(0, 0.38fr) repeat(2, minmax(0, 0.31fr));
 
   grid-template-areas:
-    'top top'
-    'needs payment'
-    'tickets payment'
-    'history history';
+    'top'
+    'needs'
+    'tickets'
+    'payment';
   gap: clamp(4px, 0.8vh, 9px);
 }
 
 .game-top {
   border-bottom: none;
   grid-area: top;
-  grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.28fr) minmax(0, 0.27fr);
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 0.22fr) minmax(0, 0.22fr) auto;
+  align-items: center;
 }
 
 .game-top .stat-card,
@@ -61,6 +62,7 @@
   opacity: 0.45;
 }
 
+
 .tickets-panel {
   grid-area: tickets;
   justify-content: space-between;
@@ -68,18 +70,18 @@
 
 .grid-tickets {
   flex: 1;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-template-rows: repeat(2, minmax(0, 1fr));
-  gap: clamp(3px, 0.6vh, 7px);
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: clamp(3px, 0.7vh, 10px);
   min-height: 0;
-  align-content: stretch;
-  justify-items: stretch;
+  flex-wrap: nowrap;
 }
 
 .ticket-btn {
   position: relative;
-  width: 100%;
+  width: auto;
+  flex: 0 1 clamp(40px, 8vw, 64px);
   max-width: clamp(40px, 8vw, 64px);
   aspect-ratio: 5 / 6;
   display: flex;
@@ -93,7 +95,12 @@
   padding: clamp(3px, 0.6vh, 6px) clamp(3px, 0.6vh, 5px);
   color: #101820;
   box-shadow: 0 0.22vh 0.7vh rgba(0, 0, 0, 0.25);
-  margin: 0 auto;
+  margin: 0;
+}
+
+.ticket-btn.is-inactive {
+  opacity: 0.35;
+  pointer-events: none;
 }
 
 .ticket-btn .ticket-icon {
@@ -196,34 +203,18 @@
 
 .currency-grid {
   flex: 1;
-  display: grid;
-  grid-template-rows: repeat(2, minmax(0, 1fr));
-  grid-template-columns: 1fr;
-  gap: clamp(3px, 0.6vh, 7px);
-  min-height: 0;
-  justify-items: center;
-  align-content: center;
-}
-
-.coins-row {
-  display: grid;
+  display: flex;
   align-items: stretch;
-  justify-items: center;
-  gap: clamp(3px, 0.6vh, 7px);
+  justify-content: space-between;
+  gap: clamp(3px, 0.7vh, 10px);
   min-height: 0;
-}
-
-.coins-row.bills {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.coins-row.coins {
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  flex-wrap: nowrap;
 }
 
 .currency-btn {
   position: relative;
-  width: 100%;
+  width: auto;
+  flex: 0 1 clamp(36px, 7vw, 60px);
   max-width: clamp(36px, 7vw, 60px);
   display: flex;
   flex-direction: column;
@@ -236,7 +227,7 @@
   box-shadow: 0 0.22vh 0.7vh rgba(0, 0, 0, 0.35);
   text-align: center;
   padding: clamp(2px, 0.4vh, 4px) clamp(3px, 0.6vh, 5px);
-  margin: 0 auto;
+  margin: 0;
 }
 
 .currency-btn.coin {
@@ -249,6 +240,7 @@
   aspect-ratio: 7 / 4;
   border-radius: clamp(6px, 0.9vh, 10px);
   max-width: clamp(52px, 10vw, 84px);
+  flex-basis: clamp(52px, 10vw, 84px);
 }
 
 .currency-btn .denom-icon {
@@ -308,53 +300,8 @@
 }
 
 
-.history-row {
-  grid-area: history;
-  display: grid;
-  grid-template-columns: minmax(0, 0.66fr) minmax(0, 0.34fr);
-  gap: clamp(3px, 0.6vh, 7px);
-  min-height: 0;
-  align-items: stretch;
-}
-
-.history-panel {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  padding: clamp(4px, 0.7vh, 8px) clamp(5px, 0.9vh, 9px);
-}
-
-.history-list {
-  flex: 1;
-}
-
-.action-panel {
-  display: grid;
-  grid-template-rows: repeat(3, minmax(0, 1fr));
-  gap: clamp(3px, 0.6vh, 6px);
-  justify-content: stretch;
-  padding: clamp(4px, 0.7vh, 8px) clamp(5px, 0.9vh, 9px);
-}
-
-.action-panel .btn {
-  width: 100%;
-  min-height: 0;
-  font-size: clamp(9px, 1.3vh, 14px);
-}
-
 @media (max-width: 1100px) {
-  .game-screen {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto minmax(0, 0.42fr) minmax(0, 0.42fr) minmax(0, 0.28fr) minmax(0, 0.24fr);
-    grid-template-areas:
-      'top'
-      'needs'
-      'tickets'
-      'payment'
-      'history';
-  }
-
-  .history-row {
-    grid-template-columns: minmax(0, 0.6fr) minmax(0, 0.4fr);
+  .game-top {
+    grid-template-columns: minmax(0, 0.5fr) minmax(0, 0.24fr) minmax(0, 0.24fr) auto;
   }
 }


### PR DESCRIPTION
## Summary
- prevent mobile zooming and reposition game controls to remove the history/actions block
- place all ticket types and currency options into single, balanced rows with updated spacing and styling
- add an in-header clear button plus a top-right close control that navigates back to the menu

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d811b879348329b855766fa1a398ec