### PR TITLE
Refine ticket gating and payment feedback

### DIFF
--- a/js/game/effects.js
+++ b/js/game/effects.js
@@ -1,0 +1,207 @@
+import { playClickSound } from '../util/sound.js';
+
+const scoreAnimations = new WeakMap();
+
+const getNow = () => (typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now());
+
+function toNumber(value, fallback = 0) {
+  const result = Number.parseFloat(value);
+  return Number.isFinite(result) ? result : fallback;
+}
+
+export function playClickFeedback(element) {
+  if (!(element instanceof HTMLElement)) {
+    playClickSound();
+    return;
+  }
+
+  playClickSound();
+
+  const animation = element.animate(
+    [
+      { transform: 'scale(1)', filter: 'brightness(1)', boxShadow: 'none' },
+      {
+        transform: 'scale(1.08)',
+        filter: 'brightness(1.05)',
+        boxShadow: '0 0 18px rgba(255, 222, 133, 0.55)',
+      },
+      { transform: 'scale(1)', filter: 'brightness(1)', boxShadow: 'none' },
+    ],
+    { duration: 220, easing: 'ease-out' }
+  );
+
+  animation.addEventListener('finish', () => {
+    if (element && element.isConnected) {
+      element.style.filter = '';
+    }
+  });
+}
+
+export function animateFlyToScore(source, target) {
+  if (!(source instanceof HTMLElement) || !(target instanceof HTMLElement)) {
+    return;
+  }
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const sourceRect = source.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+
+  const clone = source.cloneNode(true);
+  if (!(clone instanceof HTMLElement)) {
+    return;
+  }
+  clone.classList.add('flying-token');
+  clone.removeAttribute('id');
+  clone.style.position = 'fixed';
+  clone.style.top = `${sourceRect.top}px`;
+  clone.style.left = `${sourceRect.left}px`;
+  clone.style.width = `${sourceRect.width}px`;
+  clone.style.height = `${sourceRect.height}px`;
+  clone.style.pointerEvents = 'none';
+  clone.style.margin = '0';
+  clone.style.zIndex = '9999';
+  clone.style.opacity = '0.9';
+
+  document.body.appendChild(clone);
+
+  const deltaX = targetRect.left + targetRect.width / 2 - (sourceRect.left + sourceRect.width / 2);
+  const deltaY = targetRect.top + targetRect.height / 2 - (sourceRect.top + sourceRect.height / 2);
+
+  const animation = clone.animate(
+    [
+      { transform: 'translate(0, 0) scale(1)', opacity: 0.9 },
+      {
+        transform: `translate(${deltaX}px, ${deltaY}px) scale(0.35)`,
+        opacity: 0,
+        offset: 1,
+      },
+    ],
+    { duration: 520, easing: 'cubic-bezier(0.32, 0.8, 0.36, 1)' }
+  );
+
+  const removeClone = () => {
+    clone.remove();
+  };
+
+  animation.addEventListener('finish', removeClone, { once: true });
+  animation.addEventListener('cancel', removeClone, { once: true });
+}
+
+export function playErrorFeedback(element) {
+  if (!(element instanceof HTMLElement)) {
+    playClickSound();
+    return;
+  }
+
+  playClickSound();
+
+  const animation = element.animate(
+    [
+      { transform: 'scale(1)', filter: 'none', boxShadow: 'none' },
+      {
+        transform: 'scale(0.95)',
+        filter: 'saturate(0.4)',
+        boxShadow: '0 0 18px rgba(240, 70, 70, 0.55)',
+      },
+      { transform: 'scale(1)', filter: 'none', boxShadow: 'none' },
+    ],
+    { duration: 250, easing: 'ease-out' }
+  );
+
+  animation.addEventListener('finish', () => {
+    if (element && element.isConnected) {
+      element.style.filter = '';
+    }
+  });
+}
+
+export function animateScoreValue(element, value) {
+  if (!(element instanceof HTMLElement)) {
+    return;
+  }
+
+  const target = Math.max(0, Math.round(Number(value) || 0));
+  const currentText = element.dataset.displayValue ?? element.textContent ?? '0';
+  const current = Math.max(0, Math.round(toNumber(currentText, 0)));
+
+  if (current === target) {
+    element.dataset.displayValue = String(target);
+    element.textContent = String(target);
+    return;
+  }
+
+  const previous = scoreAnimations.get(element);
+  if (previous?.raf) {
+    cancelAnimationFrame(previous.raf);
+  }
+
+  const start = current;
+  const delta = target - start;
+  const duration = 520;
+  const startTime = getNow();
+
+  const state = {};
+
+  const step = (timestamp) => {
+    const elapsed = timestamp - startTime;
+    const progress = Math.min(1, elapsed / duration);
+    const eased = 1 - Math.pow(1 - progress, 3);
+    const valueNow = Math.round(start + delta * eased);
+    element.textContent = String(valueNow);
+    element.dataset.displayValue = String(valueNow);
+    if (progress < 1) {
+      state.raf = requestAnimationFrame(step);
+    } else {
+      scoreAnimations.delete(element);
+    }
+  };
+
+  state.raf = requestAnimationFrame(step);
+  scoreAnimations.set(element, state);
+}
+
+export function applyTimerVisual(timerElement, timeLeft) {
+  if (!(timerElement instanceof HTMLElement)) {
+    return;
+  }
+  const seconds = Math.max(0, Math.ceil(Number(timeLeft) || 0));
+  timerElement.textContent = `${seconds} s`;
+
+  let state = 'normal';
+  if (seconds <= 5) {
+    state = 'critical';
+  } else if (seconds <= 10) {
+    state = 'warning';
+  }
+
+  timerElement.dataset.state = state;
+  if (state === 'critical') {
+    timerElement.classList.add('is-pulsing');
+  } else {
+    timerElement.classList.remove('is-pulsing');
+  }
+}
+
+export function applyScoreVisual(scoreElement, scoreValue) {
+  if (!(scoreElement instanceof HTMLElement)) {
+    return;
+  }
+  const score = Math.round(Number(scoreValue) || 0);
+  const tone = score >= 0 ? 'positive' : 'negative';
+  scoreElement.dataset.tone = tone;
+}
+
+export function highlightPays(cardElement, mode = 'complete') {
+  if (!(cardElement instanceof HTMLElement)) {
+    return;
+  }
+  const className = mode === 'reveal' ? 'is-reveal' : 'is-highlight';
+  cardElement.classList.add(className);
+  const handleEnd = () => {
+    cardElement.classList.remove(className);
+    cardElement.removeEventListener('animationend', handleEnd);
+  };
+  cardElement.addEventListener('animationend', handleEnd);
+}

--- a/js/game/render.js
+++ b/js/game/render.js
@@ -1,4 +1,5 @@
 import { ALL_TICKETS } from './constants.js';
+import { animateScoreValue, applyScoreVisual, applyTimerVisual, highlightPays } from './effects.js';
 
 const currency = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -54,10 +55,10 @@ export function renderTickets(session, elements, handlers) {
     `;
 
     if (isAvailable) {
-      button.addEventListener('click', () => handlers.onAddTicket(ticket.name));
+      button.addEventListener('click', (event) => handlers.onAddTicket(ticket.name, event));
       button.addEventListener('contextmenu', (event) => {
         event.preventDefault();
-        handlers.onRemoveTicket(ticket.name);
+        handlers.onRemoveTicket(ticket.name, event);
       });
     }
 
@@ -91,17 +92,29 @@ export function renderCoins(session, elements, handlers) {
       <span class="denom-value">${formatMoney(denomination.value)}</span>
       <span class="denom-label">${denomination.label}</span>
     `;
-    button.addEventListener('click', () => handlers.onInsertCoin(denomination.value));
+    const locked = !session.canPay;
+    button.disabled = locked;
+    button.tabIndex = locked ? -1 : 0;
+    button.setAttribute('aria-disabled', locked ? 'true' : 'false');
+    button.classList.toggle('is-locked', locked);
+    button.addEventListener('click', (event) => {
+      if (button.disabled) {
+        return;
+      }
+      handlers.onInsertCoin(denomination.value, event);
+    });
     fragment.appendChild(button);
   });
 
   coinsWrap.classList.add('grid-coins');
+  coinsWrap.dataset.locked = !session.canPay ? 'true' : 'false';
   coinsWrap.replaceChildren(fragment);
 }
 
 export function updateHud(session, elements) {
   const { scoreDisplay, needEl, paysEl, fareEl, pickedEl, remainEl, timerDisplay, changeWrap, paysCard } = elements;
-  scoreDisplay.textContent = Math.max(0, Math.round(session.score));
+  animateScoreValue(scoreDisplay, session.score);
+  applyScoreVisual(scoreDisplay, session.score);
   needEl.textContent = formatRequest(session.request);
   if (session.showPays) {
     paysEl.textContent = formatMoney(session.pays);
@@ -109,6 +122,18 @@ export function updateHud(session, elements) {
   } else {
     paysEl.textContent = '—';
     paysCard?.classList.add('is-muted');
+  }
+  if (paysCard) {
+    const state = session.payFlashShown ? 'complete' : session.showPays ? 'revealed' : 'hidden';
+    paysCard.dataset.state = state;
+  }
+  if (session.payRevealPending && paysCard) {
+    highlightPays(paysCard, 'reveal');
+    session.payRevealPending = false;
+  }
+  if (session.payFlashPending && paysCard) {
+    highlightPays(paysCard, 'complete');
+    session.payFlashPending = false;
   }
   fareEl.textContent = formatMoney(session.ticketTotal);
   pickedEl.textContent = formatMoney(session.selectedTotal);
@@ -150,7 +175,7 @@ export function updateHud(session, elements) {
       remainEl.removeAttribute('data-state');
     }
   }
-  timerDisplay.textContent = `${Math.max(0, Math.ceil(session.timeLeft))} s`;
+  applyTimerVisual(timerDisplay, session.timeLeft);
 }
 
 export function renderHistory(session, elements) {

--- a/js/game/rng.js
+++ b/js/game/rng.js
@@ -41,7 +41,7 @@ function roundToCents(value) {
 
 export function rollBusConfig() {
   const minTypes = 2;
-  const maxTypes = Math.min(7, ALL_TICKETS.length);
+  const maxTypes = Math.min(6, ALL_TICKETS.length);
   const desired = clampInt(triangularInt(minTypes, maxTypes, 4), minTypes, maxTypes);
 
   const base = ALL_TICKETS.filter((ticket) => ALWAYS_INCLUDED.has(ticket.name));

--- a/js/game/state.js
+++ b/js/game/state.js
@@ -27,6 +27,11 @@ function baseRoundState(timeLimit) {
     history: [],
     showChange: false,
     showPays: false,
+    payRevealPending: false,
+    payRevealShown: false,
+    canPay: false,
+    payFlashPending: false,
+    payFlashShown: false,
     roundStartTime: 0,
     roundBonuses: [],
   };

--- a/js/screens/game.js
+++ b/js/screens/game.js
@@ -3,6 +3,7 @@ import { SESSION, startSession, endSession } from '../game/state.js';
 import { startRound, finishRound, stopRound } from '../game/round.js';
 import { addTicket, removeTicket, clearTickets, insertCoin } from '../game/actions.js';
 import { renderTickets, renderCoins, updateHud, renderHistory, showOverlay, hideOverlay } from '../game/render.js';
+import { playClickFeedback, playErrorFeedback, animateFlyToScore } from '../game/effects.js';
 import { recordScore } from '../storage/db.js';
 
 const params = new URLSearchParams(window.location.search);
@@ -38,15 +39,36 @@ let roundActive = false;
 let finishing = false;
 
 const ticketHandlers = {
-  onAddTicket: (name) => {
+  onAddTicket: (name, event) => {
     if (!roundActive) return;
-    if (addTicket(SESSION, name)) {
+    const button = event?.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    const added = addTicket(SESSION, name);
+    if (button) {
+      if (added) {
+        playClickFeedback(button);
+      } else {
+        playErrorFeedback(button);
+      }
+    }
+    if (added && button && elements.scoreDisplay) {
+      animateFlyToScore(button, elements.scoreDisplay);
+    }
+    if (added) {
       syncUI();
     }
   },
-  onRemoveTicket: (name) => {
+  onRemoveTicket: (name, event) => {
     if (!roundActive) return;
-    if (removeTicket(SESSION, name)) {
+    const button = event?.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    const removed = removeTicket(SESSION, name);
+    if (button) {
+      if (removed) {
+        playClickFeedback(button);
+      } else {
+        playErrorFeedback(button);
+      }
+    }
+    if (removed) {
       syncUI();
     }
   },
@@ -54,10 +76,23 @@ const ticketHandlers = {
 
 const coinHandlers = {
   getAvailableCoins: () => getAvailableDenominations(SESSION.coinOptions),
-  onInsertCoin: (value) => {
+  onInsertCoin: (value, event) => {
     if (!roundActive) return;
-    insertCoin(SESSION, value);
-    syncUI();
+    const button = event?.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    const inserted = insertCoin(SESSION, value);
+    if (button) {
+      if (inserted) {
+        playClickFeedback(button);
+      } else {
+        playErrorFeedback(button);
+      }
+    }
+    if (inserted) {
+      if (button && elements.scoreDisplay) {
+        animateFlyToScore(button, elements.scoreDisplay);
+      }
+      syncUI();
+    }
   },
 };
 
@@ -66,7 +101,34 @@ function navigateToMenu() {
 }
 
 function syncUI() {
+  const requestEntries = Object.entries(SESSION.request);
+  const ticketsMatch = requestEntries.every(([name, count]) => (SESSION.selectedTickets[name] || 0) === count);
+  const noExtraTickets = Object.keys(SESSION.selectedTickets).every(
+    (name) => (SESSION.request[name] || 0) === SESSION.selectedTickets[name]
+  );
+  const ticketsComplete = requestEntries.length > 0 && ticketsMatch && noExtraTickets;
+  SESSION.canPay = ticketsComplete;
+  if (ticketsComplete) {
+    SESSION.showPays = true;
+    if (!SESSION.payRevealShown) {
+      SESSION.payRevealPending = true;
+      SESSION.payRevealShown = true;
+    }
+  } else {
+    SESSION.showPays = false;
+    SESSION.payRevealPending = false;
+    SESSION.payRevealShown = false;
+  }
+
+  if (!ticketsComplete) {
+    SESSION.payFlashPending = false;
+    SESSION.payFlashShown = false;
+  } else if (SESSION.changeDue === 0 && !SESSION.payFlashShown) {
+    SESSION.payFlashPending = true;
+    SESSION.payFlashShown = true;
+  }
   renderTickets(SESSION, elements, ticketHandlers);
+  renderCoins(SESSION, elements, coinHandlers);
   updateHud(SESSION, elements);
   renderHistory(SESSION, elements);
   maybeFinishRound();

--- a/js/util/sound.js
+++ b/js/util/sound.js
@@ -1,0 +1,47 @@
+let audioContext = null;
+
+function getContext() {
+  if (typeof window === 'undefined' || typeof window.AudioContext === 'undefined') {
+    return null;
+  }
+  if (!audioContext) {
+    try {
+      audioContext = new window.AudioContext();
+    } catch (error) {
+      audioContext = null;
+    }
+  }
+  if (audioContext && audioContext.state === 'suspended') {
+    audioContext.resume().catch(() => {});
+  }
+  return audioContext;
+}
+
+export function playClickSound() {
+  const ctx = getContext();
+  if (!ctx) {
+    return;
+  }
+  const now = ctx.currentTime;
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  oscillator.type = 'triangle';
+  oscillator.frequency.setValueAtTime(920, now);
+  oscillator.frequency.exponentialRampToValueAtTime(640, now + 0.14);
+
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(0.22, now + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.2);
+
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+
+  oscillator.start(now);
+  oscillator.stop(now + 0.22);
+
+  oscillator.addEventListener('ended', () => {
+    oscillator.disconnect();
+    gain.disconnect();
+  });
+}

--- a/styles/game.css
+++ b/styles/game.css
@@ -24,8 +24,45 @@
 }
 
 .game-top .stat-card .value,
-.game-top .timer {
-  font-size: var(--font-display);
+.game-top .timer-card .timer {
+  font-size: clamp(28px, 5.8vh, 64px);
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+#score {
+  color: #ffd166;
+}
+
+.game-top .timer-card .timer {
+  color: #6ce5b1;
+}
+
+#score[data-tone='positive'] {
+  color: #ffd166;
+  text-shadow: 0 0 14px rgba(255, 209, 102, 0.45);
+}
+
+#score[data-tone='negative'] {
+  color: #ff4d4f;
+  text-shadow: none;
+}
+
+.timer-card .timer[data-state='normal'] {
+  color: #6ce5b1;
+}
+
+.timer-card .timer[data-state='warning'] {
+  color: #ffb347;
+}
+
+.timer-card .timer[data-state='critical'] {
+  color: #ff4d4f;
+}
+
+.timer-card .timer.is-pulsing {
+  animation: timerPulse 0.8s ease-in-out infinite;
 }
 
 .needs-panel,
@@ -93,7 +130,7 @@
   border: none;
   border-radius: clamp(6px, 0.9vh, 10px);
   padding: clamp(3px, 0.6vh, 6px) clamp(3px, 0.6vh, 5px);
-  color: #101820;
+  color: #000;
   box-shadow: 0 0.22vh 0.7vh rgba(0, 0, 0, 0.25);
   margin: 0;
 }
@@ -101,14 +138,16 @@
 .ticket-btn.is-inactive {
   pointer-events: none;
   opacity: 1;
-  background: linear-gradient(160deg, #4d5565 0%, #2d323d 100%);
-  color: #e5e8ef;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  background: #bfc3ce !important;
+  color: #000 !important;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+  filter: grayscale(0.2);
 }
 
 .ticket-btn.is-inactive .sub,
-.ticket-btn.is-inactive .ticket-price {
-  color: #f5f7fb;
+.ticket-btn.is-inactive .ticket-price,
+.ticket-btn.is-inactive .ticket-icon {
+  color: #000 !important;
 }
 
 .ticket-btn .ticket-icon {
@@ -120,10 +159,12 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   font-size: clamp(8px, 1.1vh, 12px);
+  color: #000;
 }
 
 .ticket-btn .ticket-price {
   font-size: clamp(10px, 1.4vh, 14px);
+  color: #000;
 }
 
 .ticket-btn .bubble {
@@ -260,6 +301,23 @@
   box-shadow: 0 0.4vh 1.1vh rgba(16, 61, 41, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 
+.currency-btn.is-locked {
+  background: #c9ced9 !important;
+  color: #2d3036 !important;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+  filter: grayscale(0.4);
+}
+
+.currency-btn.is-locked .denom-label,
+.currency-btn.is-locked .denom-value,
+.currency-btn.is-locked .denom-icon {
+  color: rgba(24, 26, 32, 0.7);
+}
+
+.currency-btn.is-locked:disabled {
+  opacity: 1;
+}
+
 .currency-btn .denom-icon {
   font-size: clamp(7px, 1vh, 11px);
   opacity: 0.7;
@@ -300,6 +358,54 @@
   color: rgba(15, 36, 24, 0.55);
 }
 
+.currency-grid[data-locked='true'] {
+  opacity: 0.75;
+}
+
+.currency-grid[data-locked='false'] {
+  opacity: 1;
+}
+
+#paysCard {
+  position: relative;
+}
+
+#paysCard .value {
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+#paysCard[data-state='hidden'] .value {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+#paysCard[data-state='revealed'] .value {
+  color: #ffffff;
+  text-shadow: 0 0 14px rgba(255, 255, 255, 0.25);
+}
+
+#paysCard[data-state='complete'] .value {
+  color: #ffd166;
+  text-shadow: 0 0 12px rgba(255, 209, 102, 0.45);
+}
+
+#paysCard.is-highlight {
+  animation: paysFlash 0.65s ease;
+}
+
+#paysCard.is-reveal {
+  animation: paysReveal 0.55s ease;
+}
+
+.flying-token {
+  border-radius: inherit;
+  overflow: hidden;
+  box-shadow: 0 0 18px rgba(255, 220, 120, 0.4);
+}
+
+.timer-card .timer.is-pulsing {
+  will-change: transform;
+}
+
 .score-bonus-toast {
   position: absolute;
   left: 50%;
@@ -316,6 +422,59 @@
   pointer-events: none;
   animation: scoreBonusFloat 0.9s ease forwards;
   box-shadow: 0 0.4vh 1.1vh rgba(255, 209, 102, 0.35);
+}
+
+@keyframes timerPulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes paysFlash {
+  0% {
+    transform: translateX(0);
+    box-shadow: 0 0 0 rgba(255, 209, 102, 0.4);
+  }
+  15% {
+    transform: translateX(-3px);
+  }
+  30% {
+    transform: translateX(3px);
+    box-shadow: 0 0 20px rgba(255, 209, 102, 0.6);
+  }
+  50% {
+    transform: translateX(-2px);
+  }
+  70% {
+    transform: translateX(2px);
+  }
+  100% {
+    transform: translateX(0);
+    box-shadow: 0 0 0 rgba(255, 209, 102, 0.4);
+  }
+}
+
+@keyframes paysReveal {
+  0% {
+    transform: scale(0.92);
+    filter: brightness(0.75);
+  }
+  60% {
+    transform: scale(1.08);
+    filter: brightness(1.2);
+    box-shadow: 0 0 22px rgba(255, 255, 255, 0.3);
+  }
+  100% {
+    transform: scale(1);
+    filter: none;
+    box-shadow: 0 0 0 rgba(255, 255, 255, 0);
+  }
 }
 
 @keyframes scoreBonusFloat {


### PR DESCRIPTION
## Summary
- Keep non-active ticket types visibly greyed-out regardless of their theme colors and add a distinct reveal animation for the Pays card when tickets are complete.
- Gate the Pays value and currency controls until the ticket request is satisfied, and trigger the gold completion flash only after the correct change is provided.
- Add red error feedback for invalid ticket and coin selections while preventing overpayment and exposing coins only once the player can make change.

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d8e015a4f8832997cad6b1f004c4a7