### PR TITLE
Fix horizontal ticket sizing in left-right layout

### DIFF
--- a/styles/game.css
+++ b/styles/game.css
@@ -130,12 +130,12 @@
 
 .game-screen[data-layout='left-right'] .grid-tickets {
   display: grid;
-  grid-template-columns: repeat(4, minmax(auto, clamp(40px, 8vw, 64px)));
-  grid-auto-rows: minmax(0, auto);
-  gap: clamp(3px, 0.8vh, 12px);
-  justify-content: center;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: clamp(5px, 1vh, 14px);
+  justify-content: stretch;
   align-content: flex-start;
-  justify-items: center;
+  justify-items: stretch;
+  align-items: start;
 }
 
 .ticket-btn {
@@ -159,9 +159,9 @@
 }
 
 .game-screen[data-layout='left-right'] .grid-tickets .ticket-btn {
-  width: auto;
-  max-width: clamp(40px, 8vw, 64px);
-  justify-self: center;
+  width: 100%;
+  max-width: none;
+  justify-self: stretch;
 }
 
 .ticket-btn.is-inactive {


### PR DESCRIPTION
## Summary
- expand horizontal ticket grid columns to share equal space across the panel
- stretch ticket buttons to occupy their grid tracks for consistent sizing and spacing

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d9d5580c2c83298a85ac6c6d3bc376